### PR TITLE
TX inhibit GPIO support

### DIFF
--- a/audio.h
+++ b/audio.h
@@ -198,6 +198,12 @@ struct audio_s {
 
 	    } octrl[NUM_OCTYPES];
 
+	    struct {
+	    	int enabled;
+	    	int gpio;
+		int invert;
+	    } txinh;
+
 	/* Transmit timing. */
 
 	    int dwait;			/* First wait extra time for receiver squelch. */

--- a/config.c
+++ b/config.c
@@ -1450,6 +1450,30 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 
 	  }  /* end of PTT */
 
+/*
+ * TXINH		- Input for TX inhibit signal
+ */
+
+	  else if (strcasecmp(t, "TXINH") == 0) {
+	    t = strtok (NULL, " ,\t\n\r");
+	    if (t == NULL) {
+	      text_color_set(DW_COLOR_ERROR);
+	      dw_printf ("Config file line %d: Missing GPIO number for TXINH.\n",
+		    line);
+	      continue;
+	    }
+	    
+	    p_audio_config->achan[channel].txinh.enabled = 1;
+
+	    if (*t == '-') {
+	      p_audio_config->achan[channel].txinh.gpio = atoi(t+1);
+	      p_audio_config->achan[channel].txinh.invert = 1;
+	    }
+	    else {
+	      p_audio_config->achan[channel].txinh.gpio = atoi(t);
+	      p_audio_config->achan[channel].txinh.invert = 0;
+	    }
+	  }  /* end of TXINH */
 
 /*
  * DWAIT 		- Extra delay for receiver squelch.

--- a/hdlc_rec.c
+++ b/hdlc_rec.c
@@ -678,7 +678,7 @@ int hdlc_rec_data_detect_any (int chan)
 	  }
 	  close (fd);
 
-	  if (atoi(vtemp) == save_audio_config_p->achan[chan].txinh.invert) busy = 1; 
+	  if (atoi(vtemp) != save_audio_config_p->achan[chan].txinh.invert) busy = 1; 
 	}
 #endif
 

--- a/hdlc_rec.c
+++ b/hdlc_rec.c
@@ -48,6 +48,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <stdlib.h>
 #endif
 
 
@@ -644,7 +645,7 @@ static void dcd_change (int chan, int subchan, int state)
 int hdlc_rec_data_detect_any (int chan)
 {
 	int subchan;
-	int busy;
+	int busy = 0;
 
 	assert (chan >= 0 && chan < MAX_CHANS);
 
@@ -668,7 +669,8 @@ int hdlc_rec_data_detect_any (int chan)
 	    return (busy != 1);
 	  }
 
-	  if (read (fd, stemp, 1) != 1) {
+	  char vtemp[2];
+	  if (read (fd, vtemp, 1) != 1) {
 	    int e = errno;
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("Error getting GPIO %d value for TXINH\n", save_audio_config_p->achan[chan].txinh.gpio);
@@ -676,14 +678,11 @@ int hdlc_rec_data_detect_any (int chan)
 	  }
 	  close (fd);
 
-	  char vtemp[2];
-	  sprintf (vtemp, "%d", save_audio_config_p->achan[chan].txinh.invert);
-
-	  if (!strcmp (stemp, vtemp)) busy = 1; 
+	  if (atoi(vtemp) == save_audio_config_p->achan[chan].txinh.invert) busy = 1; 
 	}
 #endif
 
-	return (busy != 1);
+	return (busy != 0);
 
 } /* end hdlc_rec_data_detect_any */
 

--- a/hdlc_rec.c
+++ b/hdlc_rec.c
@@ -45,6 +45,7 @@
 #if __WIN32__
 #else
 #include <fcntl.h>
+#include <unistd.h>
 #include <errno.h>
 #include <string.h>
 #endif
@@ -664,7 +665,7 @@ int hdlc_rec_data_detect_any (int chan)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("Error opening %s to check TXINH.\n", stemp);
 	    dw_printf ("%s\n", strerror(e));
-	    return;
+	    return busy;
 	  }
 
 	  if (read (fd, stemp, 1) != 1) {
@@ -682,7 +683,7 @@ int hdlc_rec_data_detect_any (int chan)
 	}
 #endif
 
-	return busy;
+	return (busy != 1);
 
 } /* end hdlc_rec_data_detect_any */
 

--- a/hdlc_rec.c
+++ b/hdlc_rec.c
@@ -665,7 +665,7 @@ int hdlc_rec_data_detect_any (int chan)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("Error opening %s to check TXINH.\n", stemp);
 	    dw_printf ("%s\n", strerror(e));
-	    return busy;
+	    return (busy != 1);
 	  }
 
 	  if (read (fd, stemp, 1) != 1) {

--- a/textcolor.c
+++ b/textcolor.c
@@ -111,19 +111,19 @@ static const char clear_eos[]	= "\e[0J";
 /* expected bright/bold (1) to get bright white background. */
 /* Makes no sense but I stumbled across that somewhere. */
 
-static const char background_white[] = "\e[5;47m";
+static const char background_white[] = "\e[49m";
 
 /* Whenever a dark color is used, the */
 /* background is reset and needs to be set again. */
 
-static const char black[]	= "\e[0;30m" "\e[5;47m";
-static const char red[] 	= "\e[1;31m" "\e[5;47m";
-static const char green[] 	= "\e[1;32m" "\e[5;47m";
-static const char yellow[] 	= "\e[1;33m" "\e[5;47m";
-static const char blue[] 	= "\e[1;34m" "\e[5;47m";
-static const char magenta[] 	= "\e[1;35m" "\e[5;47m";
-static const char cyan[] 	= "\e[1;36m" "\e[5;47m";
-static const char dark_green[]	= "\e[0;32m" "\e[5;47m";
+static const char black[]	= "\e[0;39m" "\e[49m";
+static const char red[] 	= "\e[1;31m" "\e[49m";
+static const char green[] 	= "\e[1;32m" "\e[49m";
+static const char yellow[] 	= "\e[1;33m" "\e[49m";
+static const char blue[] 	= "\e[1;34m" "\e[49m";
+static const char magenta[] 	= "\e[1;35m" "\e[49m";
+static const char cyan[] 	= "\e[1;36m" "\e[49m";
+static const char dark_green[]	= "\e[0;32m" "\e[49m";
 
 /* Clear from cursor to end of screen. */
 


### PR DESCRIPTION
These changes allow to user to specify a Raspberry Pi GPIO line that keeps Dire Wolf from transmitting when the line is active. I implemented this for an APRS igate/digi that will be at a site that will be sharing air time with a packet messaging system. The ham club would like the existing system to take priority and inhibit the igate from transmitting when DCD is detected on the other frequency, hopefully avoiding desensitizing that receiver. It ties into the existing DCD code so Dire Wolf will give up if it waits too long for a clear channel.

I'd imagine you'll want to change this code to suit your style, but feel free to use the idea.