### PR TITLE
Fixes to Makefile.macosx

### DIFF
--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -11,14 +11,6 @@
 
 
 all : direwolf decode_aprs text2tt tt2text ll2utm utm2ll aclients atest log2gpx gen_packets ttcalc direwolf.conf
-	@echo " "
-	@echo "Next step install with: "
-	@echo " "
-	@echo "      sudo make install"
-	@echo " "
-	@echo "System SDK's (10.8 - 10.10) must be located here to make use of them. "
-	@echo "     /Developer/SDKs "
-	@echo " "
 
 SDK_PATH := $(shell xcrun --show-sdk-path)
 SDK_VERSION := $(shell xcrun --show-sdk-version)

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -20,29 +20,10 @@ all : direwolf decode_aprs text2tt tt2text ll2utm utm2ll aclients atest log2gpx 
 	@echo "     /Developer/SDKs "
 	@echo " "
 
-SYS_LIBS :=
-SYS_MIN :=
-SDK := $(shell find /Developer -maxdepth 1 -type d -name "SDKs")
-#$(info $$SDK = ${SDK})
-ifeq (${SDK},/Developer/SDKs)
-	SDK := $(shell find /Developer/SDKs -maxdepth 1 -type d -name "MacOSX10.8.sdk")
-	ifeq (${SDK},/Developer/SDKs/MacOSX10.8.sdk)
-		SYS_LIBS := -isystem /Developer/SDKs/MacOSX10.8.sdk
-		SYS_MIN := -mmacosx-version-min=10.8
-	else
-		SDK := $(shell find /Developer/SDKs -maxdepth 1 -type d -name "MacOSX10.9.sdk")
-		ifeq (${SDK},/Developer/SDKs/MacOSX10.9.sdk)
-			SYS_LIBS := -isystem /Developer/SDKs/MacOSX10.9.sdk
-			SYS_MIN := -mmacosx-version-min=10.9
-		else
-			SDK := $(shell find /Developer/SDKs -maxdepth 1 -type d -name "MacOSX10.10.sdk")
-			ifeq (${SDK},/Developer/SDKs/MacOSX10.10.sdk)
-				SYS_LIBS := -isystem /Developer/SDKs/MacOSX10.10.sdk
-				SYS_MIN := -mmacosx-version-min=10.10
-			endif
-		endif
-	endif
-endif
+SDK_PATH := $(shell xcrun --show-sdk-path)
+SDK_VERSION := $(shell xcrun --show-sdk-version)
+SYS_LIBS := -isystem ${SDK_PATH}
+SYS_MIN := -mmacosx-version-min=${SDK_VERSION}
 
 EXTRA_CFLAGS :=
 DARWIN_CC := $(shell which clang)
@@ -169,19 +150,19 @@ endif
 # Use PortAudio Library
 
 # Force static linking of portaudio if the static library is available.
-PA_LIB_STATIC := $(shell find /opt/local/lib -maxdepth 1 -type f -name "libportaudio.a")
+PA_LIB_STATIC := $(shell find /usr/local/lib -maxdepth 1 -type f -name "libportaudio.a")
 #$(info $$PA_LIB_STATIC is [${PA_LIB_STATIC}])
 ifeq (${PA_LIB_STATIC},)
-LDLIBS += -L/opt/local/lib -lportaudio
+LDLIBS += -L/usr/local/lib -lportaudio
 else
-LDLIBS += /opt/local/lib/libportaudio.a
+LDLIBS += /usr/local/lib/libportaudio.a
 endif
 
 # Include libraries portaudio requires.
 LDLIBS += -framework CoreAudio -framework AudioUnit -framework AudioToolbox
 LDLIBS += -framework Foundation -framework CoreServices
 
-CFLAGS += -DUSE_PORTAUDIO -I/opt/local/include
+CFLAGS += -DUSE_PORTAUDIO -I/usr/local/include
 
 # Uncomment following lines to enable GPS interface & tracker function.
 # Not available for MacOSX.

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -142,19 +142,19 @@ endif
 # Use PortAudio Library
 
 # Force static linking of portaudio if the static library is available.
-PA_LIB_STATIC := $(shell find /usr/local/lib -maxdepth 1 -type f -name "libportaudio.a")
+PA_LIB_STATIC := $(shell find /opt/local/lib -maxdepth 1 -type f -name "libportaudio.a")
 #$(info $$PA_LIB_STATIC is [${PA_LIB_STATIC}])
 ifeq (${PA_LIB_STATIC},)
-LDLIBS += -L/usr/local/lib -lportaudio
+LDLIBS += -L/opt/local/lib -lportaudio
 else
-LDLIBS += /usr/local/lib/libportaudio.a
+LDLIBS += /opt/local/lib/libportaudio.a
 endif
 
 # Include libraries portaudio requires.
 LDLIBS += -framework CoreAudio -framework AudioUnit -framework AudioToolbox
 LDLIBS += -framework Foundation -framework CoreServices
 
-CFLAGS += -DUSE_PORTAUDIO -I/usr/local/include
+CFLAGS += -DUSE_PORTAUDIO -I/opt/local/include
 
 # Uncomment following lines to enable GPS interface & tracker function.
 # Not available for MacOSX.

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -472,7 +472,7 @@ depend : $(wildcard *.c)
 
 .PHONY: clean
 clean :
-	rm -f direwolf decode_aprs text2tt tt2text ll2utm utm2ll aclients atest log2gpx gen_packets ttcalc \
+	rm -f direwolf decode_aprs text2tt tt2text ll2utm utm2ll aclients atest log2gpx gen_fff gen_packets ttcalc \
 		fsk_fast_filter.h *.o *.a
 	echo " " > tune.h
 

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -26,12 +26,7 @@ else
 EXTRA_CFLAGS := -fvectorize -fslp-vectorize -fslp-vectorize-aggressive -pthread
 endif
 
-# Change as required in support of the available libraries
-
-#CC := $(DARWIN_CC) -m64 $(SYS_LIBS) $(SYS_MIN)
-CC := $(DARWIN_CC) -m32 $(SYS_LIBS) $(SYS_MIN)
 CFLAGS := -Os -pthread -Igeotranz $(EXTRA_CFLAGS)
-# $(info $$CC is [${CC}])
 
 #
 # The DSP filters spend a lot of time spinning around in little

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -151,12 +151,14 @@ LDLIBS += -framework Foundation -framework CoreServices
 
 CFLAGS += -DUSE_PORTAUDIO -I/opt/local/include
 
-# Uncomment following lines to enable GPS interface & tracker function.
-# Not available for MacOSX.
-# Although MacPorts has gpsd, wonder if it's the same thing.
 
-#CFLAGS += -DENABLE_GPSD
-#LDLIBS += -lgps
+# Enable GPS interface and tracker function if the gpsd package is installed.
+
+ifeq ($(shell which -s gpsd),)
+	CFLAGS += -DENABLE_GPSD
+	LDLIBS += -lgps
+endif
+
 
 # Name of current directory.
 # Used to generate zip file name for distribution.
@@ -401,7 +403,7 @@ testagc : atest.c demod.c dsp.c demod_afsk.c demod_9600.c hdlc_rec.c hdlc_rec2.o
 
 atest : atest.c fsk_fast_filter.h demod.c dsp.c demod_afsk.c demod_9600.c hdlc_rec.c hdlc_rec2.o multi_modem.o rrbb.o \
 		fcs_calc.c ax25_pad.c decode_aprs.c dwgpsnmea.o dwgps.o serial_port.o telemetry.c latlong.c symbols.c textcolor.c tt_text.c
-	$(CC) $(CFLAGS) -o $@ $^ -lm
+	$(CC) $(CFLAGS) $^ -lm
 
 # Unit test for inner digipeater algorithm
 
@@ -461,6 +463,7 @@ depend : $(wildcard *.c)
 clean :
 	rm -f direwolf decode_aprs text2tt tt2text ll2utm utm2ll aclients atest log2gpx gen_fff gen_packets ttcalc \
 		fsk_fast_filter.h *.o *.a
+	rm -rf aclients.dSYM
 	echo " " > tune.h
 
 


### PR DESCRIPTION
- Replaced logic that determines what version of OS X SDK is installed, and where. Assuming the existence of /Developer produced make errors on 10.11. This is likely due to the fact that XCODE installs to /Applications by default (when installed via App Store). Use of the xcrun tool seems to be a more reliable way to make the determinations.
- Replaced instances of /opt with /usr. Assuming the existence of /opt caused make errors for 10.11. According to 'man hier', the file system hierarchy information, /opt is not used on OS X. If there is a standard location for shared libraries, it is maybe /usr/local/lib. (**Reverted -- see commit f71eab3)**
