### PR TITLE
Misc fixes for upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,20 @@ direwolf.conf
 *.wav
 fsk_fast_filter.h
 
+# Binaries
+aclients
+atest
+decode_aprs
+direwolf
+direwolf.desktop
+gen_fff
+gen_packets
+ll2utm
+log2gpx
+text2tt
+tt2text
+ttcalc
+utm2ll
 
 # Object files
 *.o

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -327,7 +327,7 @@ gen_packets : gen_packets.c ax25_pad.c hdlc_send.c fcs_calc.c gen_tone.c morse.c
 
 # Unit test for AFSK demodulator
 
-atest : atest.c fsk_fast_filter.h demod.c demod_afsk.c demod_9600.c \
+atest : atest.c demod.o demod_afsk.o demod_9600.c \
 		dsp.o hdlc_rec.c hdlc_rec2.o multi_modem.o rrbb.o \
 		fcs_calc.c ax25_pad.c decode_aprs.c dwgpsnmea.o \
 		dwgps.o dwgpsd.o serial_port.o telemetry.c latlong.c symbols.c tt_text.c textcolor.c \
@@ -692,7 +692,7 @@ itest : igate.c textcolor.c ax25_pad.c fcs_calc.c textcolor.o misc.a
 
 # Unit test for UDP reception with AFSK demodulator
 
-udptest : udp_test.c demod.c dsp.c demod_afsk.c demod_9600.c hdlc_rec.c hdlc_rec2.c multi_modem.c rrbb.c 
+udptest : udp_test.c demod.o dsp.c demod_afsk.o demod_9600.c hdlc_rec.c hdlc_rec2.c multi_modem.c rrbb.c \
 		fcs_calc.c ax25_pad.c decode_aprs.c symbols.c textcolor.c misc.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 	./udptest
@@ -701,7 +701,7 @@ demod.o : tune.h
 demod_afsk.o : tune.h
 demod_9600.o : tune.h
 
-testagc : atest.c demod.c dsp.c demod_afsk.c demod_9600.c hdlc_rec.c hdlc_rec2.o multi_modem.o rrbb.o \
+testagc : atest.c demod.o dsp.c demod_afsk.o demod_9600.c hdlc_rec.c hdlc_rec2.o multi_modem.o rrbb.o \
 		fcs_calc.c ax25_pad.c decode_aprs.c telemetry.c latlong.c symbols.c tune.h textcolor.c misc.a
 	$(CC) $(CFLAGS) -o atest $^ $(LDFLAGS)
 	./atest 02_Track_2.wav | grep "packets decoded in" > atest.out

--- a/aclients.c
+++ b/aclients.c
@@ -67,6 +67,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <fcntl.h>

--- a/audio.c
+++ b/audio.c
@@ -1134,7 +1134,7 @@ int audio_flush (int a)
 {
 #if USE_ALSA
 	int k;
-	char *psound;
+	unsigned char *psound;
 	int retries = 10;
 	snd_pcm_status_t *status;
 

--- a/config.c
+++ b/config.c
@@ -1233,7 +1233,7 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 		  /* Later, we check for valid letters and no more than one letter if + specified. */
 
 	          for (pc = t; *pc != '\0'; pc++) {
-		    if ( ! isalpha(*pc) && ! *pc == '+') {
+		    if ( ! isalpha(*pc) && ! (*pc == '+')) {
 	              text_color_set(DW_COLOR_ERROR);
                       dw_printf ("Line %d: Demodulator type can only contain letters and + character.\n", line);
 		    }

--- a/demod_afsk.c
+++ b/demod_afsk.c
@@ -720,7 +720,7 @@ static void emit_macro (char *name, int size, float *coeff)
 	dw_printf ("\n");
 }
 
-int main ()
+int main (void)
 {
 	//int n;
 	char fff_profile;

--- a/dwgpsd.c
+++ b/dwgpsd.c
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <errno.h>
 #include <time.h>
+#include <math.h>
 
 #if __WIN32__
 #error Not for Windows

--- a/igate.c
+++ b/igate.c
@@ -78,6 +78,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #endif

--- a/kiss.c
+++ b/kiss.c
@@ -685,7 +685,7 @@ void kiss_send_rec_packet (int chan, unsigned char *fbuf,  int flen)
 	    text_color_set(DW_COLOR_DEBUG);
 	    dw_printf ("\n");
 	    dw_printf ("Packet content before adding KISS framing and any escapes:\n");
-	    hex_dump ((char*)fbuf, flen);
+	    hex_dump (fbuf, flen);
 	  }
 
 	  kiss_len = kiss_encapsulate (stemp, flen+1, kiss_buff);

--- a/kissnet.c
+++ b/kissnet.c
@@ -511,7 +511,7 @@ void kissnet_send_rec_packet (int chan, unsigned char *fbuf, int flen)
 	    text_color_set(DW_COLOR_DEBUG);
 	    dw_printf ("\n");
 	    dw_printf ("Packet content before adding KISS framing and any escapes:\n");
-	    hex_dump ((char*)fbuf, flen);
+	    hex_dump (fbuf, flen);
 	  }
 
 	  kiss_len = kiss_encapsulate (stemp, flen+1, kiss_buff);

--- a/ttcalc.c
+++ b/ttcalc.c
@@ -57,6 +57,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/errno.h>


### PR DESCRIPTION
This PR contains a bug fix for reading config files, a number of warning fixes, and a fix that allows Clang to be used to compile direwolf.