### PR TITLE
Disable color on non-tty output

### DIFF
--- a/textcolor.c
+++ b/textcolor.c
@@ -77,6 +77,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <unistd.h>
 
 
 #if __WIN32__
@@ -207,7 +208,7 @@ void text_color_init (int enable_color)
 	g_enable_color = enable_color;
 
 
-	if (g_enable_color == 0) {
+	if (g_enable_color == 0 || isatty(fileno(stdout)) == 0) {
 		return;
 	}
 #if __WIN32__
@@ -250,7 +251,7 @@ void text_color_set ( enum dw_color_e c )
 	WORD attr;
 	HANDLE h;
 
-	if (g_enable_color == 0) {
+	if (g_enable_color == 0 || isatty(fileno(stdout)) == 0) {
 	  return;
 	}
 
@@ -294,7 +295,7 @@ void text_color_set ( enum dw_color_e c )
 void text_color_set ( enum dw_color_e c )
 {
 
-	if (g_enable_color == 0) {
+	if (g_enable_color == 0 || isatty(fileno(stdout)) == 0) {
 	  return;
 	}
 

--- a/textcolor.c
+++ b/textcolor.c
@@ -207,37 +207,35 @@ void text_color_init (int enable_color)
 	g_enable_color = enable_color;
 
 
+	if (g_enable_color == 0) {
+		return;
+	}
 #if __WIN32__
 
 
-	if (g_enable_color) {
 
-	  HANDLE h;
-	  CONSOLE_SCREEN_BUFFER_INFO csbi;
-	  WORD attr = BACKGROUND_WHITE;
-	  DWORD length;
-	  COORD coord;
-	  DWORD nwritten;
+	HANDLE h;
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+	WORD attr = BACKGROUND_WHITE;
+	DWORD length;
+	COORD coord;
+	DWORD nwritten;
 
-	  h = GetStdHandle(STD_OUTPUT_HANDLE);
-	  if (h != NULL && h != INVALID_HANDLE_VALUE) {
+	h = GetStdHandle(STD_OUTPUT_HANDLE);
+	if (h != NULL && h != INVALID_HANDLE_VALUE) {
 
-	    GetConsoleScreenBufferInfo (h, &csbi);
+		GetConsoleScreenBufferInfo (h, &csbi);
 
-	    length = csbi.dwSize.X * csbi.dwSize.Y;
-	    coord.X = 0; 
-	    coord.Y = 0;
-	    FillConsoleOutputAttribute (h, attr, length, coord, &nwritten);
-	  }
+		length = csbi.dwSize.X * csbi.dwSize.Y;
+		coord.X = 0;
+		coord.Y = 0;
+		FillConsoleOutputAttribute (h, attr, length, coord, &nwritten);
 	}
-
 #else
-	if (g_enable_color) {
-	  //printf ("%s", clear_eos);
-	  printf ("%s", background_white);
-	  printf ("%s", clear_eos);
-	  printf ("%s", black);
-	}
+	//printf ("%s", clear_eos);
+	printf ("%s", background_white);
+	printf ("%s", clear_eos);
+	printf ("%s", black);
 #endif
 }
 


### PR DESCRIPTION
This fixes a litany of problems that arise from attempting to parse output using other tools (such as diff to compare unit test output between revisions).
