### PR TITLE
Fix kissattach 'Device or resource busy'

### DIFF
--- a/kiss.c
+++ b/kiss.c
@@ -906,14 +906,6 @@ static int kiss_get (/* MYFDTYPE fd*/ void )
 	    dw_printf ("\nError receiving kiss message from client application.  Closing %s.\n\n", pt_slave_name);
 	    perror ("");
 
-	    /* Message added between 1.1 beta test and final version 1.1 */
-
-	    /* TODO: Determine root cause and find proper solution. */
-
-	    dw_printf ("This is a known problem that sometimes shows up when using with kissattach.\n");
-	    dw_printf ("There are a couple work-arounds described in the Dire Wolf User Guide\n");
-	    dw_printf ("and the Raspberry Pi APRS documents.\n");
-
 	    close (pt_master_fd);
 
 	    pt_master_fd = MYFDERROR;


### PR DESCRIPTION
Hi,

I got bit by the kissattach issue mentioned in the user guide on Debian Jessie. I though it was strange, because I've written a program, fldigiattach, that exposes a pty slave to kissattach. I never experienced the issue.

After some debugging I realized that the only real difference between fldigiattach and the code in kiss.c was that fldigiattach, which is written in Go, indirectly uses non-blocking IO syscalls. This got me thinking that maybe the blocking read from pt_master_fd was causing the "Device or resource busy" error seen by kissattach.

This fix resolves the issue by using select() to wait for data before reading from the master fd.

I've confirmed the fix on Debian Jessie.