### PR TITLE
Fix up some spelling and man page formatting

### DIFF
--- a/config.c
+++ b/config.c
@@ -4299,7 +4299,7 @@ static int beacon_options(char *cmd, struct beacon_s *b, int line, struct audio_
 	  }
 	  else {
 	    text_color_set(DW_COLOR_ERROR);
-	    dw_printf ("Config file, line %d: When any of ZONE, EASTING, NORTHING specifed, they must all be specified.\n", line);
+	    dw_printf ("Config file, line %d: When any of ZONE, EASTING, NORTHING specified, they must all be specified.\n", line);
 	  }
 	}
 

--- a/decode_aprs.c
+++ b/decode_aprs.c
@@ -1417,7 +1417,7 @@ static void aprs_mic_e (decode_aprs_t *A, packet_t pp, unsigned char *info, int 
  *
  * Outputs:	??? TBD
  *
- * Description:	An APRS message is a text string with a specifed addressee.
+ * Description:	An APRS message is a text string with a specified addressee.
  *
  *		It's a lot more complicated with different types of addressees
  *		and replies with acknowledgement or rejection.

--- a/gen_packets.c
+++ b/gen_packets.c
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
 
         if (strlen(output_file) == 0) {
           text_color_set(DW_COLOR_ERROR); 
-          dw_printf ("ERROR: The -o ouput file option must be specified.\n");
+          dw_printf ("ERROR: The -o output file option must be specified.\n");
           usage (argv);
           exit (1);
         }

--- a/man1/decode_aprs.1
+++ b/man1/decode_aprs.1
@@ -46,9 +46,11 @@ Dire Wolf will usually tell you what is wrong.  First,
 cut-n-paste the bad packets into a text file.  Here a couple examples:
 .P
 .RS
+.nf
 n2cma>APRS,TCPIP*,qAC,SEVENTH:@212127z43.2333n/77.1w_338/002g001t025P000h65b10208.wview_5_19_0
 .P
 K0YTH-10>APNU3B,NULL,qAR,K0DMF-10:!4601.5NS09255.52W#PHG6360/W2,MNn 444.575
+.fi
 .RE
 .P
 If  you  simply  fed  this  into decode_aprs, it would complain about the 

--- a/man1/direwolf.1
+++ b/man1/direwolf.1
@@ -133,13 +133,13 @@ gqrx (2.3 and later) has the ability to send streaming audio through a UDP socke
 direwolf can listen over a UDP port with options like this:
 .RS
 .P
-direwolf -n 1 -r 48000 -b 16 udp:7355
+direwolf \-n 1 \-r 48000 \-b 16 udp:7355
 .RE
 .P
 Other SDR applications might produce audio on stdout so it is convenient to pipe into the next application.  In this example, the final "-" means read from stdin.
 .RS
 .P
-rtl_fm -f 144.39M -o 4 - | direwolf -n 1 -r 24000 -b 16 -
+rtl_fm \-f 144.39M \-o 4 \- | direwolf \-n 1 \-r 24000 \-b 16 \-
 .RE
 
 

--- a/man1/gen_packets.1
+++ b/man1/gen_packets.1
@@ -5,12 +5,12 @@ gen_packets \- Generate audio file for AX.25 frames.
 
 
 .SH SYNOPSIS
-.B gen_packets -o 
+.B gen_packets \-o
 .I wav-file-out 
-[ \fIoptions\fR ] [ \fItext-file\fR | - ]
+[ \fIoptions\fR ] [ \fItext-file\fR | \- ]
 .RS
 .P
-\fIwav-file-out\fR is the result.  The -o option is required.
+\fIwav-file-out\fR is the result.  The \-o option is required.
 .P
 \fItext-file\fR may contain AX.25 packets in the standard monitoring format.  Use "-" to read from stdin.  If not specified, a default builtin message will be used.
 .RE
@@ -25,7 +25,7 @@ It is very flexible allowing a wide range of audio sample rates, data speeds, an
 
 .TP
 .BI  "-a " "n"
-Signal amplitude in range of 0 - 200%.  Default 50.  Note that 100% is corresponds to signal peaks of +/- 16383 so we have plenty of headroom to avoid saturation.
+Signal amplitude in range of 0-200%.  Default 50.  Note that 100% is corresponds to signal peaks of +/- 16383 so we have plenty of headroom to avoid saturation.
 
 .TP
 .BI  "-b " "n"
@@ -70,7 +70,7 @@ Send output to .wav file.
 
 .SH EXAMPLES
 .P
-.B gen_packets -o x.wav
+.B gen_packets \-o x.wav
 .P
 .RS
 With all defaults, a built-in test message is generated
@@ -78,27 +78,27 @@ with standard Bell 202 tones used for packet radio on ordinary
 VHF FM transceivers.
 .RE
 .P
-.B gen_packets -o x.wav -g -b 9600
+.B gen_packets \-o x.wav \-g \-b 9600
 .PD 0
 .P
 .PD
-.B gen_packets -o x.wav -B 9600
+.B gen_packets \-o x.wav \-B 9600
 .P
 .RS
 Both of these are equivalent.  "-B 9600" automatically selects scrambled baseband rather than AFSK.
 .RE
 .P
-.B gen_packets -o x.wav -m 1600 -s 1800 -b 300
+.B gen_packets \-o x.wav \-m 1600 \-s 1800 \-b 300
 .PD 0
 .P
 .PD
-.B gen_packets -o x.wav -B 300
+.B gen_packets \-o x.wav \-B 300
 .P
 .RS
 Both of these generate 200 Hz shift, 300 baud, suitable for HF SSB transceiver.
 .RE
 .P
-.B echo -n 'WB2OSZ>WORLD:Hello, world!' | gen_packets -a 25 -o x.wav -
+.B echo \-n 'WB2OSZ>WORLD:Hello, world!' | gen_packets \-a 25 \-o x.wav \-
 .PD 0
 .P
 .PD


### PR DESCRIPTION
Hi,

During Debian packaging I noticed a few small spelling errors and man page formatting errors.

These are fixed in this pull request. For the 1.3 release I am shipping a patch that contains these fixes locally in the Debian package.

Thanks,
Iain.
