### PR TITLE
Do not overwrite existing CFLAGS and LDFLAGS

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -12,9 +12,9 @@ all :  $(APPS) direwolf.desktop direwolf.conf
 	@echo " "
 
 CC := gcc
-CFLAGS := -O3 -pthread -Igeotranz
+CFLAGS += -O3 -pthread -Igeotranz
 
-LDFLAGS := -lm -lpthread -lrt
+LDFLAGS += -lm -lpthread -lrt
 
 
 


### PR DESCRIPTION
Hi,

In your Makefile.linux you overwrite the compiler flags that are currently set in the build environment. This disables a number of hardening options that are set in the Debian build environment by default, causing errors to be thrown when checking the resulting binaries.

These changes include the existing CFLAGS and LDFLAGS and append options to them, instead of just overwriting them.

Thanks,
Iain.
