### PR TITLE
Adds IGNOREEMPTY=[0|1] to {P,C}BEACON cmd.

### DIFF
--- a/beacon.c
+++ b/beacon.c
@@ -761,11 +761,13 @@ static void beacon_send (int j, dwgps_info_t *gpsinfo)
 	          strlcat (super_comment, var_comment, sizeof(super_comment));
 	        }
 	        else {
-		  text_color_set(DW_COLOR_ERROR);
-	    	  dw_printf ("xBEACON, config file line %d, COMMENTCMD failure.\n", g_misc_config_p->beacon[j].lineno);
-	        }
+                if (k < 0 || !g_misc_config_p->beacon[j].ignore_empty_cmd_stdout) {
+                    text_color_set(DW_COLOR_ERROR);
+                    dw_printf ("xBEACON, config file line %d, COMMENTCMD failure.\n", g_misc_config_p->beacon[j].lineno);
+                }
+                strlcpy (super_comment, "", sizeof(super_comment)); /* abort */
+            }
 	      }
-
 
 /* 
  * Add the info part depending on beacon type. 
@@ -882,9 +884,11 @@ static void beacon_send (int j, dwgps_info_t *gpsinfo)
 	              strlcat (beacon_text, info_part, sizeof(beacon_text));
 	            }
 	            else {
-		      text_color_set(DW_COLOR_ERROR);
-	    	      dw_printf ("CBEACON, config file line %d, INFOCMD failure.\n", g_misc_config_p->beacon[j].lineno);
-		      strlcpy (beacon_text, "", sizeof(beacon_text));  // abort!
+                    if(k < 0 || !g_misc_config_p->beacon[j].ignore_empty_cmd_stdout) {
+                        text_color_set(DW_COLOR_ERROR);
+                        dw_printf ("CBEACON, config file line %d, INFOCMD failure.\n", g_misc_config_p->beacon[j].lineno);
+                    }
+		            strlcpy (beacon_text, "", sizeof(beacon_text));  // abort!
 	            }
 		  }
 		  else {

--- a/config.c
+++ b/config.c
@@ -4379,6 +4379,9 @@ static int beacon_options(char *cmd, struct beacon_s *b, int line, struct audio_
 	  else if (strcasecmp(keyword, "INFOCMD") == 0) {
 	    b->custom_infocmd = strdup(value);
 	  }
+	  else if (strcasecmp(keyword, "IGNOREEMPTY") == 0) {
+	    b->ignore_empty_cmd_stdout = atoi(value);
+	  }
 	  else if (strcasecmp(keyword, "OBJNAME") == 0) {
 	    strlcpy(b->objname, value, sizeof(b->objname));
 	  }

--- a/config.h
+++ b/config.h
@@ -145,7 +145,8 @@ struct misc_config_s {
 	  char *comment;	/* Comment or NULL. */
 	  char *commentcmd;	/* Command to append more to Comment or NULL. */
 
-
+      int ignore_empty_cmd_stdout; /* Do not print an error when infocmd exits
+                                      with status 0, and no output is generated. */
 	} beacon[MAX_BEACONS];
 
 };


### PR DESCRIPTION
When using COMMENTCMD (PBEACON), or INFOCMD (CBEACON), direwolf reports
an error when the command does not produce any stdout, even when the
command exits with status 0.

This commit allows something like:

PBEACON IGNOREEMPTY=1 EVERY=00:30 COMMENTCMD='command_to_print_updates'

Say 'command_to_print_updates' only prints to stdout when its output
would be different from the last time it ran. With the above, direwolf
would run the command as before, but does not print an error when no new
updates are available. An error is still reported if the exit status is
not 0.
