### PR TITLE
Enable building Dire Wolf using PortAudio from Homebrew.

### DIFF
--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -68,8 +68,12 @@ endif
 
 # Change as required in support of the available libraries
 
-#CC := $(DARWIN_CC) -m64 $(SYS_LIBS) $(SYS_MIN)
+UNAME_M := $(shell uname -m)
+ifeq (${UNAME_M},x86_64)
+CC := $(DARWIN_CC) -m64 $(SYS_LIBS) $(SYS_MIN)
+else
 CC := $(DARWIN_CC) -m32 $(SYS_LIBS) $(SYS_MIN)
+endif
 CFLAGS := -Os -pthread -Igeotranz $(EXTRA_CFLAGS)
 # $(info $$CC is [${CC}])
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ This should give you the most recent stable release.  If you want the latest (un
 
 For more details see the **User Guide** in the [doc directory](https://github.com/wb2osz/direwolf/tree/master/doc).  Special considerations for the Raspberry Pi are found in **Raspberry-Pi-APRS.pdf**
 
+## Mac OS X ##
+
+You should have the Xcode developer tools installed. You can then install PortAudio using MacPort, following the instructions in Chapter 6 of the [User Guide](doc/User-Guide.pdf). However, a much simpler method might be to install Homebrew:
+
+1. Install [Homebrew](http://brew.sh/) if you don't have it already
+1. `brew install portaudio`
+
+Finally, follow either of the instructions given above for installing on Linux.
+
 ## Join the conversation  ##
  
 Here are some good places to share information:


### PR DESCRIPTION
This patch to `Makefile.macosx` checks `uname -m` and compiles a 64-bit binary if the machine name is `x86_64`, which makes it easy to build Dire Wolf against PortAudio as installed from [Homebrew](http://brew.sh), which IMHO is a much simpler option than Mac Ports for highly technical users of OS X.

Compiles and works on my Mac OS X Yosemite.

I also included quick install instructions for Mac OS X to `README.md`.

73 DE N0GIS