### PR TITLE
Trivvial issue with dw-start.sh, missing a $LOGFILE

### DIFF
--- a/dw-start.sh
+++ b/dw-start.sh
@@ -50,7 +50,7 @@ fi
 # Otherwise default to :0.
 #
 
-date >> /tmp/dw-start.log
+date >> $LOGFILE
 
 export DISPLAY=":0"
 


### PR DESCRIPTION
It's trivial, but it triggered me while working on something else.