### PR TITLE
Add option to use SCREEN instead of X for remote console

### DIFF
--- a/dw-start.sh
+++ b/dw-start.sh
@@ -16,18 +16,31 @@
 #
 
 #
+# For normal operation as TNC, digipeater, IGate, etc.
+# Print audio statistics each 100 seconds for troubleshooting.
+#
+
+DWCMD="direwolf -a 100"
+
+#
+# Set the logfile location
+#
+
+LOGFILE=/tmp/dw-start.log
+
+#
 # When running from cron, we have a very minimal environment
 # including PATH=/usr/bin:/bin.
 #
 
 export PATH=/usr/local/bin:$PATH
 
-# First wait a little while in case we just rebooted
-# and the desktop hasn't started up yet.
 #
+# If we are going to use screen, we put our screen binary in
+# the USESCREEN variable, otherwise, set it to 0
 
-sleep 30
-LOGFILE=/tmp/dw-start.log
+USESCREEN=/usr/bin/screen
+
 
 #
 # Nothing to do if it is already running.
@@ -40,6 +53,35 @@ then
   #echo "Already running." >> $LOGFILE
   exit
 fi
+
+# First wait a little while in case we just rebooted
+# and the desktop hasn't started up yet.
+#
+
+sleep 30
+
+#
+# If we are going the SCREEN route, then we need to 
+# see if we have a session open and if not, open it.
+#
+if [ -x $USESCREEN ]
+then
+
+  # If there is no screen running, then we need one to attach to
+  #
+  if screen -list | awk '{print $1}' | grep -q "direwolf$"; then
+    echo "screen direwolf already exists" >> $LOGFILE
+  else
+    echo "creating direwolf screen session" >> $LOGFILE
+    screen -d -m -S direwolf
+  fi
+  sleep 1
+
+  screen -S direwolf -X screen -t Direwolf $DWCMD 
+  exit 0
+
+fi
+
 
 #
 # In my case, the Raspberry Pi is not connected to a monitor.
@@ -65,12 +107,6 @@ echo "DISPLAY=$DISPLAY" >> $LOGFILE
 
 echo "Start up application." >> $LOGFILE
 
-#
-# For normal operation as TNC, digipeater, IGate, etc.
-# Print audio statistics each 100 seconds for troubleshooting.
-#
-
-DWCMD="direwolf -a 100"
 
 # Alternative for running with SDR receiver.
 # Piping one application into another makes it a little more complicated.

--- a/dw-start.sh
+++ b/dw-start.sh
@@ -50,7 +50,7 @@ fi
 # Otherwise default to :0.
 #
 
-date >> /tmp/dw-start.log
+date >> $LOGFILE
 
 export DISPLAY=":0"
 


### PR DESCRIPTION
This patch changes dw-start.sh to give the option to use SCREEN as the execution display.  SCREEN is a text based terminal multiplexer (think lxterminal for text, with tabs and the like) and works great for detached/remotely running applications, without the overhead of X, and then attaching as needed via SSH or the like.  If you have screen installed, you can specify it in the dw-start.sh script in the USESCREEN variable at the top of the file.

If USESCREEN is specified, then after the 30 second wait, the script will check to see if there is an existing SCREEN session named "direwolf", if not then it starts it in the background.  Next, direwolf is started in its own screen in side of the "direwolf" screen session.

To attach to this screen remotely, you can ssh in and then execute "screen -S direwolf -D -RR" and monitor direwolf.  If you want to detach, you can use C-x C-d to detach and you can then reattach later or leave it running.

I moved a few items around because the screen section will need some of those variables sooner than the X stuff that is left alone at the bottom.

Tested on my RPi from command line and through reboots.