### PR TITLE
Mac build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+/use_this_sdk
+*.dSYM

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -36,27 +36,6 @@ all :  $(APPS) direwolf.conf
 
 SYS_LIBS :=
 SYS_MIN :=
-#SDK := $(shell find /Developer -maxdepth 1 -type d -name "SDKs")
-#$(info $$SDK = ${SDK})
-#ifeq (${SDK},/Developer/SDKs)
-#	SDK := $(shell find /Developer/SDKs -maxdepth 1 -type d -name "MacOSX10.8.sdk")
-#	ifeq (${SDK},/Developer/SDKs/MacOSX10.8.sdk)
-#		SYS_LIBS := -isystem /Developer/SDKs/MacOSX10.8.sdk
-#		SYS_MIN := -mmacosx-version-min=10.8
-#	else
-#		SDK := $(shell find /Developer/SDKs -maxdepth 1 -type d -name "MacOSX10.9.sdk")
-#		ifeq (${SDK},/Developer/SDKs/MacOSX10.9.sdk)
-#			SYS_LIBS := -isystem /Developer/SDKs/MacOSX10.9.sdk
-#			SYS_MIN := -mmacosx-version-min=10.9
-#		else
-#			SDK := $(shell find /Developer/SDKs -maxdepth 1 -type d -name "MacOSX10.10.sdk")
-#			ifeq (${SDK},/Developer/SDKs/MacOSX10.10.sdk)
-#				SYS_LIBS := -isystem /Developer/SDKs/MacOSX10.10.sdk
-#				SYS_MIN := -mmacosx-version-min=10.10
-#			endif
-#		endif
-#	endif
-#endif
 
 SYS_LIBS := $(shell ./search_sdks.sh)
 EXTRA_CFLAGS :=
@@ -70,8 +49,12 @@ endif
 
 # Change as required in support of the available libraries
 
-#CC := $(DARWIN_CC) -m64 $(SYS_LIBS) $(SYS_MIN)
+UNAME_M := $(shell uname -m)
+ifeq (${UNAME_M},x86_64)
+CC := $(DARWIN_CC) -m64 $(SYS_LIBS) $(SYS_MIN)
+else
 CC := $(DARWIN_CC) -m32 $(SYS_LIBS) $(SYS_MIN)
+endif
 
 # _XOPEN_SOURCE=600 and _DEFAULT_SOURCE=1 are needed for glibc >= 2.24.
 # Explanation here:  https://github.com/wb2osz/direwolf/issues/62

--- a/direwolf.h
+++ b/direwolf.h
@@ -253,7 +253,7 @@ typedef pthread_mutex_t dw_mutex_t;
 // but always using send/recv makes more sense.
 // Need option to prevent a SIGPIPE signal on Linux.  (added for 1.5 beta 2)
 
-#if __WIN32__
+#if __WIN32__ || __APPLE__
 #define SOCK_SEND(s,data,size) send(s,data,size,0)
 #else
 #define SOCK_SEND(s,data,size) send(s,data,size, MSG_NOSIGNAL)

--- a/search_sdks.sh
+++ b/search_sdks.sh
@@ -43,7 +43,7 @@ if [ $valid_flag -eq "0" ]; then
 
     prompt="Select SDK to use:"
 
-    loc1=( $(find /Applications/XCode.app -type d -name "MacOSX10.*.sdk") )
+    loc1=( $(find /Applications/Xcode.app -type l -name "MacOSX10.*.sdk") )
     loc2=( $(find /Developer/SDKs -maxdepth 1 -type d -name "MacOSX10.*.sdk") )
 
     options=("${loc1[@]}" "${loc2[@]}")


### PR DESCRIPTION
Here are a few changes I had to make in order to get Dire Wolf to build on my mac, running macOS 10.13.4

Among the changes:
- I fixed the paths used to find the SDK
- `MSG_NOSIGNAL` is not available on macOS, so I added a check for that
- Used the changes from pull request #71 by schuyler in the makefile

With these changes I'm able to build and get a running version of Dire Wolf on my Mac. Ideally, another Mac user should take a look at these changes and verify that they work for them as well.