### PR TITLE
Add support for Multi-GNSS NMEA sentences.

### DIFF
--- a/decode_aprs.c
+++ b/decode_aprs.c
@@ -920,14 +920,14 @@ static void aprs_ll_pos_time (decode_aprs_t *A, unsigned char *info, int ilen)
 
 static void aprs_raw_nmea (decode_aprs_t *A, unsigned char *info, int ilen) 
 {
-	if (strncmp((char*)info, "$GPRMC,", 7) == 0)
+	if (strncmp((char*)info, "$GPRMC,", 7) == 0 || strncmp((char *)info, "$GNRMC,", 7) == 0)
 	{
 	  float speed_knots = G_UNKNOWN;
 
 	  (void) dwgpsnmea_gprmc ((char*)info, A->g_quiet, &(A->g_lat), &(A->g_lon), &speed_knots, &(A->g_course));
 	  A->g_speed_mph = DW_KNOTS_TO_MPH(speed_knots);
 	}
-	else if (strncmp((char*)info, "$GPGGA,", 7) == 0)
+	else if (strncmp((char*)info, "$GPGGA,", 7) == 0 || strncmp((char *)info, "$GNGGA,", 7) == 0)
 	{
 	  float alt_meters = G_UNKNOWN;
 	  int num_sat = 0;

--- a/dwgpsnmea.c
+++ b/dwgpsnmea.c
@@ -274,7 +274,7 @@ static void * read_gpsnmea_thread (void *arg)
 
 /* Process sentence. */
 
-	      if (strncmp(gps_msg, "$GPRMC", 6) == 0) {
+	      if (strncmp(gps_msg, "$GPRMC", 6) == 0 || strncmp(gps_msg, "$GNRMC", 6) == 0) {
 
 		f = dwgpsnmea_gprmc (gps_msg, 0, &info.dlat, &info.dlon, &info.speed_knots, &info.track);
 
@@ -318,7 +318,7 @@ static void * read_gpsnmea_thread (void *arg)
 	        }
 
 	      }
-	      else if (strncmp(gps_msg, "$GPGGA", 6) == 0) {
+	      else if (strncmp(gps_msg, "$GPGGA", 6) == 0 || strncmp(gps_msg, "$GNGGA", 6) == 0) {
 		int nsat;
 
 		f = dwgpsnmea_gpgga (gps_msg, 0, &info.dlat, &info.dlon, &info.altitude, &nsat);


### PR DESCRIPTION
Hi,

Multi-GNSS receivers have a different NMEA talker ID ("$GN" instead of "$GP") when compared with GPS-only receivers, even though the RMC and GGA sentences are binary-compatible (prior tests performed with xastir).

This may become an issue, as multi-constellation receivers are becoming more and more widespread, and their performance/precision benefit from greater signal availability.

Kind regards.
 