### PR TITLE
Suggestion to allow much greater numbers of ADEVICE's within the configuration file

### DIFF
--- a/config.c
+++ b/config.c
@@ -993,9 +993,8 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 
 	  if (strncasecmp(t, "ADEVICE", 7) == 0) {
 	    adevice = 0;
-	    if (isdigit(t[7])) {
-	      adevice = t[7] - '0';
-	    }
+            if (strnlen(t, 9) >= 8)
+                adevice = atoi(t+7);
 
 	    if (adevice < 0 || adevice >= MAX_ADEVS) {
 	      text_color_set(DW_COLOR_ERROR);


### PR DESCRIPTION
In fiddling/testing with RTL-SDR configurations, I’ve run across the need to have > 10 ADEVICE lines.   

I’ve got GnuRadio listening on a lot of different frequencies and shuffling that audio over to Direwolf via a bunch of different UDP ports.  Consequently, for large configurations (I’ve had as many as 18 ADEVICES configured), one can’t be limited by a maximum of 10 ADEVICE lines within the config file.

This suggested change looks to use the “atoi” function to get the audio device number.

Thanks,
-Jeff
N6BA
