### PR TITLE
fix compilation on macOS

### DIFF
--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -44,7 +44,7 @@ ifeq (${DARWIN_CC},)
 DARWIN_CC := $(shell which gcc)
 EXTRA_CFLAGS :=
 else
-EXTRA_CFLAGS := -fvectorize -fslp-vectorize -fslp-vectorize-aggressive -pthread
+EXTRA_CFLAGS := -fvectorize -fslp-vectorize -pthread
 endif
 
 # Change as required in support of the available libraries

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -24,6 +24,13 @@
 # 3. Removed fsk_fast_filter.h from atest receipe, clang compiler was having
 #    a hissy fit. Not check with GCC.
 
+# Where should we install it?
+# Looks for libraries and includes, default is Homebrew
+INSTALLDIR := /usr/local
+
+# To use Macports, uncomment this line
+#INSTALLDIR := /opt/local
+
 APPS := direwolf decode_aprs text2tt tt2text ll2utm utm2ll aclients atest log2gpx gen_packets ttcalc kissutil
 
 all :  $(APPS) direwolf.conf
@@ -91,19 +98,19 @@ endif
 # Use PortAudio Library
 
 # Force static linking of portaudio if the static library is available.
-PA_LIB_STATIC := $(shell find /opt/local/lib -maxdepth 1 -type f -name "libportaudio.a")
+PA_LIB_STATIC := $(shell find $(INSTALLDIR)/lib -maxdepth 1 -type f -name "libportaudio.a")
 #$(info $$PA_LIB_STATIC is [${PA_LIB_STATIC}])
 ifeq (${PA_LIB_STATIC},)
-LDLIBS += -L/opt/local/lib -lportaudio
+LDLIBS += -L$(INSTALLDIR)/lib -lportaudio
 else
-LDLIBS += /opt/local/lib/libportaudio.a
+LDLIBS += $(INSTALLDIR)/lib/libportaudio.a
 endif
 
 # Include libraries portaudio requires.
 LDLIBS += -framework CoreAudio -framework AudioUnit -framework AudioToolbox
 LDLIBS += -framework Foundation -framework CoreServices
 
-CFLAGS += -DUSE_PORTAUDIO -I/opt/local/include
+CFLAGS += -DUSE_PORTAUDIO -I$(INSTALLDIR)/include
 
 # Uncomment following lines to enable GPS interface & tracker function.
 # Not available for MacOSX (as far as I know).
@@ -112,12 +119,12 @@ CFLAGS += -DUSE_PORTAUDIO -I/opt/local/include
 # Well never mind, issue with Macports with 64bit libs ;-( leave the check in
 # until (if ever) Macports fixes the issue.
 
-#GPS_HEADER := $(shell find /opt/local/include -maxdepth 1 -type f -name "gps.h")
+#GPS_HEADER := $(shell find $(INSTALLDIR)/include -maxdepth 1 -type f -name "gps.h")
 #ifeq (${GPS_HEADER},)
 #GPS_OBJS :=
 #else
 #CFLAGS += -DENABLE_GPSD
-#LDLIBS += -L/opt/local/lib -lgps -lgpsd
+#LDLIBS += -L$(INSTALLDIR)/lib -lgps -lgpsd
 #GPS_OBJS := dwgps.o dwgpsnmea.o dwgpsd.o
 #endif
 

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -74,8 +74,9 @@ CFLAGS += -D_BSD_SOURCE
 # get much better results by telling it we have at least a Pentium 3
 # which hass the SSE instructions.
 
-CFLAGS += -march=core2 -msse4.1 -std=gnu99
+#CFLAGS += -march=core2 -msse4.1 -std=gnu99
 #CFLAGS += -march=pentium3 -sse
+CFLAGS += -march=native
 
 
 # Add -ffastmath in only if compiler version recognizes it.

--- a/search_sdks.sh
+++ b/search_sdks.sh
@@ -85,6 +85,7 @@ if [ ! -z "$selected_sdk" ]; then
 
     # Remove the "u" if 10.4u Universal SDK is used.
     min_str="${min_str%%u}"
+    min_str="${min_str:-10.14}"
 
     system_sdk="-isystem ${selected_sdk} -mmacosx-version-min=${min_str}"
 else


### PR DESCRIPTION
These were the changes I needed to get working on macOS 10.12.3 and homebrew.

I had to do `make` twice, and there are a few warnings leftover from clang about unused linker flags, but it seems to work well enough.

I haven't tested these changes with macPorts. 