### PR TITLE
telem-seq.sh: Make compatible to busybox `sh`

### DIFF
--- a/telemetry-toolkit/telem-seq.sh
+++ b/telemetry-toolkit/telem-seq.sh
@@ -2,6 +2,10 @@
 # Generate sequence number as described here:
 # https://github.com/wb2osz/direwolf/issues/9
 #
+if [ ! -f /tmp/seq ]; then
+echo 0 > /tmp/seq
+fi
+
 SEQ=`cat /tmp/seq 2>/dev/null`
 SEQ=$(expr \( $SEQ + 1 \) % 1000)
 echo $SEQ | tee /tmp/seq


### PR DESCRIPTION
busybox's sh-implementation is differnt from the normal sh:

In busybox-expr an empty string does not evaluate to int(0).
Calling `expr ($SEQ +1)` with `SEQ=""` fails.

This patch works around this behavior by making sure the file
exists.

I left the pipe for stderr around the `cat` in place to make
sure I do not break any other error cases.

Signed-off-by: Chris Fiege <chris@tinyhost.de>