### PR TITLE
add OpenBSD support (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@
 
 win := $(shell uname | grep CYGWIN)
 dar := $(shell uname | grep Darwin)
+obsd := $(shell uname | grep OpenBSD)
 
 ifneq ($(win),)
    include Makefile.win
 else ifeq ($(dar),Darwin)
    include Makefile.macosx
+else ifeq ($(obsd),OpenBSD)
+   include Makefile.openbsd
 else
    include Makefile.linux
 endif

--- a/Makefile.openbsd
+++ b/Makefile.openbsd
@@ -1,0 +1,855 @@
+#
+# Makefile for OpenBSD version of Dire Wolf.
+#
+
+
+
+APPS := direwolf decode_aprs text2tt tt2text ll2utm utm2ll aclients atest log2gpx gen_packets ttcalc kissutil
+
+all :  $(APPS) direwolf.desktop direwolf.conf
+	@echo " "
+	@echo "Next step - install with:"
+	@echo " "
+	@echo "        sudo $(MAKE) install"
+	@echo " "
+
+CC := cc
+CFLAGS += -O3 -pthread -Igeotranz -D_XOPEN_SOURCE=600 -D_DEFAULT_SOURCE=1 -Wall
+
+# That was fine for a recent Ubuntu and Raspbian Jessie.
+# However, Raspbian wheezy was then missing declaration for strsep and definition of fd_set.
+
+CFLAGS += -D_BSD_SOURCE
+
+LDFLAGS += -lm -lpthread
+
+
+
+#
+# The DSP filters spend a lot of time spinning around in little
+# loops multiplying and adding arrays of numbers.  The Intel "SSE"
+# instructions, introduced in 1999 with the Pentium III series,
+# can speed this up considerably.
+#
+# SSE2 instructions, added in 2000, don't seem to offer any advantage.
+#
+#
+# Let's take a look at the effect of the compile options.
+#
+#
+# Times are elapsed time to process Track 2 of the TNC test CD.
+#
+# i.e.   "./atest 02_Track_2.wav"
+# Default demodulator type is new "E" added for version 1.2.
+#
+
+#
+# ---------- x86 (32 bit) ---------- 
+#
+
+#
+# clang 5.0.1 running on OpenBSD-6.3/i386.
+# AMD A10-7670K processor.
+#
+# When cc is generating code for a 32 bit x86 target, it assumes the ancient 
+# i386 processor.  This is good for portability but bad for performance.
+#
+# The code can run considerably faster by taking advantage of the SSE instructions 
+# available in the Pentium 3 or later.
+#
+#       seconds		options
+#       ---------	-------
+#         272.549	-O0
+#          97.736	-O1
+#         104.176	-O2
+#         105.030	-O3
+#         104.112	-O3 -ffast-math
+#         104.112	-Ofast
+#         104.395	-O3 -ffast-math -march=pentium
+#          51.505	-O3 -ffast-math -msse
+#          51.674	-O3 -ffast-math -march=pentium -msse
+#          51.417	-O3 -ffast-math -march=pentium3
+#          52.342	-O3 -ffast-math -march=native 
+#
+
+# If the compiler is generating code for the i386 target, we can
+# get much better results by telling it we have at least a Pentium 3.
+
+arch := $(shell echo | $(CC) -E -dM - | grep __i386__)
+ifneq ($(arch),)
+CFLAGS += -march=pentium3
+endif
+
+
+#
+# ---------- x86_64 ---------- 
+#
+
+#
+# clang 5.0.1 running on OpenBSD-6.3/amd64.
+# AMD A10-7860K processor.
+#
+# 64 bit target implies that we have SSE and probably even better vector instructions.
+#
+#       seconds		options
+#       ---------	-------
+#         217.609	-O0
+#          82.871	-O1
+#          76.537	-O2
+#          76.328	-O3
+#          82.842	-O3 -march=native
+#          42.069	-O3 -ffast-math  
+#          41.991	-Ofast
+#          49.801	-O3 -ffast-math -march=native    
+#
+
+# Add -ffastmath in only if compiler version recognizes it.
+
+useffast := $(shell $(CC) --help -v 2>/dev/null | grep ffast-math)
+ifneq ($(useffast),)
+CFLAGS += -ffast-math
+endif
+
+
+#
+# ---------- ARM - pcDuino ----------
+#
+# clang 5.0.1 running on OpenBSD-6.3/armv7.
+# Cortex-A8 (ARMv7A) + VFPv3 + NEON @ 1008MHz
+#
+#
+#       seconds		options
+#       ---------	-------
+#        8636.517	-O3 -ffast-math
+#        1321.755	-O3 -ffast-math -mfloat-abi=softfp -mfpu=vfp
+#        1320.601	-O3 -ffast-math -mfloat-abi=softfp -mfpu=vfpv3
+#        1319.413	-O3 -ffast-math -mfloat-abi=softfp -mfpu=vfpv3-d16
+#         301.106	-O3 -ffast-math -mfloat-abi=softfp -mfpu=neon
+#         303.458	-O3 -ffast-math -mfloat-abi=hard -mfpu=neon
+#
+
+#
+# ---------- ARM - Orange Pi PC ----------
+#
+# clang 5.0.1 running on OpenBSD-6.3/armv7.
+# Cortex-A7 (ARMv7A) + VFPv4 + NEON @ 1008MHz
+#
+#
+#       seconds		options
+#       ---------	-------
+#        8961.491	-O3 -ffast-math
+#         399.880	-O3 -ffast-math -mfloat-abi=softfp -mfpu=vfp
+#         400.615	-O3 -ffast-math -mfloat-abi=softfp -mfpu=vfpv3
+#         399.659	-O3 -ffast-math -mfloat-abi=softfp -mfpu=vfpv3-d16
+#         329.392	-O3 -ffast-math -mfloat-abi=softfp -mfpu=neon
+#         329.060	-O3 -ffast-math -mfloat-abi=hard -mfpu=neon
+#         398.590	-O3 -ffast-math -mfloat-abi=softfp -mfpu=vfpv4
+#         399.478	-O3 -ffast-math -mfloat-abi=softfp -mfpu=vfpv4-d16
+#         328.698	-O3 -ffast-math -mfloat-abi=softfp -mfpu=neon-vfpv4
+#
+
+#
+# XXX Currently clang on OpenBSD/armv7 requires -mfloat-abi=softfp to use
+# XXX NEON/VFP instruction. If it is omitted, extremely slow...
+#
+
+neon := $(shell machine | grep armv7)
+ifneq ($(neon),)
+CFLAGS += -mfloat-abi=softfp -mfpu=neon
+endif
+
+
+#
+# You would expect "-march=native" to produce the fastest code.
+# Why don't I use it here?
+#
+#	1. In my benchmarks, above, it has a negligible impact if any at all.
+#	2. Some older versions of gcc don't recognize "native" as a valid choice.
+#	3. Results are less portable.  Not a consideration if you are 
+#		building only for your own use but very important for anyone
+#		redistributing a "binary" version.
+#
+# If you are planning to distribute the binary version to other 
+# people (in some ham radio software collection, RPM, or DEB package), 
+# avoid fine tuning it for your particular computer.  It could
+# cause compatibility issues for those with older computers.
+#
+
+
+# Use sndio via PortAudio Library (you can install it by pkg_add portaudio-svn)
+
+LDFLAGS += -lportaudio -L/usr/local/lib
+CFLAGS += -DUSE_PORTAUDIO -I/usr/local/include
+
+
+# Enable GPS if header file is present.
+# Finding libgps.so* is more difficult because it
+# is in different places on different operating systems.
+
+# XXX API version is incompatible, currently disabled
+
+#enable_gpsd := $(wildcard /usr/local/include/gps.h)
+ifneq ($(enable_gpsd),)
+CFLAGS += -DENABLE_GPSD -I/usr/local/include
+LDFLAGS += -lgps -L/usr/local/lib
+endif
+
+
+# Enable hamlib support if header file is present.
+
+enable_hamlib := $(wildcard /usr/local/include/hamlib/rig.h)
+ifneq ($(enable_hamlib),)
+CFLAGS += -DUSE_HAMLIB
+LDFLAGS += -lhamlib
+endif
+
+
+# Name of current directory.
+# Used to generate zip file name for distribution.
+
+z := $(notdir ${CURDIR})
+
+
+
+# --------------------------------  Main application  -----------------------------------------
+
+
+
+direwolf : direwolf.o config.o recv.o demod.o dsp.o demod_afsk.o demod_psk.o demod_9600.o hdlc_rec.o \
+		hdlc_rec2.o multi_modem.o rdq.o rrbb.o dlq.o \
+		fcs_calc.o ax25_pad.o  ax25_pad2.o xid.o \
+		decode_aprs.o symbols.o server.o kiss.o kissserial.o kissnet.o kiss_frame.o hdlc_send.o fcs_calc.o \
+		gen_tone.o audio_portaudio.o audio_stats.o digipeater.o cdigipeater.o pfilter.o dedupe.o tq.o xmit.o morse.o \
+		ptt.o beacon.o encode_aprs.o latlong.o encode_aprs.o latlong.o textcolor.o \
+		dtmf.o aprs_tt.o tt_user.o tt_text.o igate.o waypoint.o serial_port.o log.o telemetry.o \
+		dwgps.o dwgpsnmea.o dwgpsd.o dtime_now.o mheard.o ax25_link.o \
+		misc.a geotranz.a
+	$(CC) -o $@ $^ $(LDFLAGS)
+	@echo " "
+ifneq ($(enable_gpsd),)
+	@echo "\t>\tThis includes support for gpsd."
+else
+	@echo "\t>\tThis does NOT include support for gpsd."
+endif
+ifneq ($(enable_hamlib),)
+	@echo "\t>\tThis includes support for hamlib."
+else
+	@echo "\t>\tThis does NOT include support for hamlib."
+endif
+
+# Optimization for slow processors.
+
+demod.o      : fsk_fast_filter.h
+
+demod_afsk.o : fsk_fast_filter.h
+
+
+fsk_fast_filter.h : gen_fff
+	./gen_fff > fsk_fast_filter.h
+
+gen_fff : demod_afsk.c dsp.c textcolor.c
+	echo " " > tune.h
+	$(CC) $(CFLAGS) -DGEN_FFF -o $@ $^ $(LDFLAGS)
+
+
+#
+# The destination field is often used to identify the manufacturer/model.
+# These are not hardcoded into Dire Wolf.  Instead they are read from
+# a file called tocalls.txt at application start up time.
+#
+# The original permanent symbols are built in but the "new" symbols,
+# using overlays, are often updated.  These are also read from files.
+#
+# You can obtain an updated copy by typing "make tocalls-symbols".
+# This is not part of the normal build process.  You have to do this explicitly.
+#
+# The locations below appear to be the most recent.
+# The copy at http://www.aprs.org/tocalls.txt is out of date.
+#
+
+.PHONY: tocalls-symbols
+tocalls-symbols :
+	cp tocalls.txt tocalls.txt~
+	wget http://www.aprs.org/aprs11/tocalls.txt -O tocalls.txt
+	-diff -Z tocalls.txt~ tocalls.txt
+	cp symbols-new.txt symbols-new.txt~
+	wget http://www.aprs.org/symbols/symbols-new.txt -O symbols-new.txt
+	-diff -Z symbols-new.txt~ symbols-new.txt
+	cp symbolsX.txt symbolsX.txt~
+	wget http://www.aprs.org/symbols/symbolsX.txt -O symbolsX.txt
+	-diff -Z symbolsX.txt~ symbolsX.txt
+
+
+# ---------------------------------------- Other utilities included ------------------------------
+
+
+# Separate application to decode raw data.
+
+# First three use .c rather than .o because they depend on DECAMAIN definition.
+
+decode_aprs : decode_aprs.c kiss_frame.c ax25_pad.c dwgpsnmea.o dwgps.o dwgpsd.o serial_port.o symbols.o textcolor.o fcs_calc.o latlong.o log.o telemetry.o tt_text.o misc.a
+	$(CC) $(CFLAGS) -DDECAMAIN -o $@ $^ $(LDFLAGS)
+
+
+
+# Convert between text and touch tone representation.
+
+text2tt : tt_text.c misc.a
+	$(CC) $(CFLAGS) -DENC_MAIN -o $@ $^ $(LDFLAGS)
+
+tt2text : tt_text.c misc.a
+	$(CC) $(CFLAGS) -DDEC_MAIN -o $@ $^ $(LDFLAGS)
+
+
+# Convert between Latitude/Longitude and UTM coordinates.
+
+ll2utm : ll2utm.c geotranz.a textcolor.o misc.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+utm2ll : utm2ll.c geotranz.a textcolor.o misc.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+
+# Convert from log file to GPX.
+
+log2gpx : log2gpx.c textcolor.o misc.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+
+# Test application to generate sound.
+
+gen_packets : gen_packets.c ax25_pad.c hdlc_send.c fcs_calc.c gen_tone.c morse.c dtmf.c textcolor.c dsp.c misc.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+# Unit test for AFSK demodulator
+
+atest : atest.c demod.o demod_afsk.o demod_psk.o demod_9600.o \
+		dsp.o hdlc_rec.o hdlc_rec2.o multi_modem.o rrbb.o \
+		fcs_calc.o ax25_pad.o decode_aprs.o dwgpsnmea.o \
+		dwgps.o dwgpsd.o serial_port.o telemetry.o dtime_now.o latlong.o symbols.o tt_text.o textcolor.o \
+		misc.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+
+# Multiple AGWPE network or serial port clients to test TNCs side by side.
+
+aclients : aclients.c ax25_pad.c fcs_calc.c textcolor.o misc.a
+	$(CC) $(CFLAGS) -g -o $@ $^ 
+
+
+# Talk to a KISS TNC.
+# Note:  kiss_frame.c has conditional compilation on KISSUTIL.
+
+kissutil : kissutil.c kiss_frame.c ax25_pad.o fcs_calc.o textcolor.o serial_port.o dtime_now.o sock.o misc.a
+	$(CC) $(CFLAGS) -g -DKISSUTIL -o $@ $^ $(LDFLAGS)
+
+
+# Touch Tone to Speech sample application.
+
+ttcalc : ttcalc.o ax25_pad.o fcs_calc.o textcolor.o misc.a
+	$(CC) $(CFLAGS) -g -o $@ $^ 
+
+
+# -----------------------------------------  Libraries  --------------------------------------------
+
+# UTM, USNG, MGRS conversions.
+
+geotranz.a : error_string.o  mgrs.o  polarst.o  tranmerc.o  ups.o  usng.o  utm.o
+	ar -cr $@ $^
+
+error_string.o : geotranz/error_string.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+mgrs.o : geotranz/mgrs.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+polarst.o : geotranz/polarst.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+tranmerc.o : geotranz/tranmerc.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+ups.o : geotranz/ups.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+usng.o : geotranz/usng.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+utm.o : geotranz/utm.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+
+# OpenBSD has strlcpy and strlcat, so misc.a is empty
+
+misc.a : 
+	ar -cr $@ $^	
+ 
+
+# -------------------------------------  Installation  ----------------------------------
+
+
+
+# Generate apprpriate sample configuration file for this platform.
+# Originally, there was one sample for all platforms.  It got too cluttered
+# and confusing saying, this is for windows, and this is for Linux, and this ...
+# Trying to maintain 3 different versions in parallel is error prone.
+# We now have a single generic version which can be used to generate
+# the various platform specific versions.
+
+# generic.conf should be checked into source control.
+# direwolf.conf should NOT.  It is generated when compiling on the target platform.
+
+direwolf.conf : generic.conf
+	egrep '^C|^L' generic.conf | cut -c2-999 > direwolf.conf
+
+
+# Where should we install it?
+
+# Something built from source and installed locally would normally go in /usr/local/...
+# If not specified on the make command line, this is our default.
+
+DESTDIR ?= /usr/local
+
+# However, if you are preparing a "binary" DEB or RPM package, the installation location
+# would normally be  /usr/...  instead.   In this case, use a command line like this:
+#
+#	make  DESTDIR=/usr  install
+
+
+
+# Command to "install" to system directories.  Use "ginstall" for Mac.
+
+INSTALL=install
+
+# direwolf.desktop was previously handcrafted for the Raspberry Pi.
+# It was hardcoded with lxterminal, /home/pi, and so on.
+# In version 1.2, try to customize this to match other situations better.
+
+# TODO:  Test this better.
+
+
+direwolf.desktop :
+	@echo "Generating customized direwolf.desktop ..."
+	@echo '[Desktop Entry]' > $@
+	@echo 'Type=Application' >> $@
+ifneq ($(wildcard /usr/bin/lxterminal),)
+	@echo "Exec=lxterminal -t \"Dire Wolf\" -e \"$(DESTDIR)/bin/direwolf\"" >> $@
+else ifneq ($(wildcard /usr/bin/lxterm),)
+	@echo "Exec=lxterm -hold -title \"Dire Wolf\" -bg white -e \"$(DESTDIR)/bin/direwolf\"" >> $@
+else
+	@echo "Exec=xterm -hold -title \"Dire Wolf\" -bg white -e \"$(DESTDIR)/bin/direwolf\"" >> $@
+endif
+	@echo 'Name=Dire Wolf' >> $@
+	@echo 'Comment=APRS Soundcard TNC' >> $@
+	@echo 'Icon=$(DESTDIR)/share/direwolf/pixmaps/dw-icon.png' >> $@
+	@echo "Path=$(HOME)" >> $@
+	@echo '#Terminal=true' >> $@
+	@echo 'Categories=HamRadio' >> $@
+	@echo 'Keywords=Ham Radio;APRS;Soundcard TNC;KISS;AGWPE;AX.25' >> $@
+
+
+# Installation into $(DESTDIR), usually /usr/local/... or /usr/...
+# Needs to be run as root or with sudo.
+
+
+.PHONY: install
+install : $(APPS) direwolf.conf tocalls.txt symbols-new.txt symbolsX.txt dw-icon.png direwolf.desktop
+#
+# Applications, not installed with package manager, normally go in /usr/local/bin.
+# /usr/bin is used instead when installing from .DEB or .RPM package.
+#
+	$(INSTALL) -D -m 755 direwolf $(DESTDIR)/bin/direwolf
+	$(INSTALL) -D -m 755 decode_aprs $(DESTDIR)/bin/decode_aprs
+	$(INSTALL) -D -m 755 text2tt $(DESTDIR)/bin/text2tt
+	$(INSTALL) -D -m 755 tt2text $(DESTDIR)/bin/tt2text
+	$(INSTALL) -D -m 755 ll2utm $(DESTDIR)/bin/ll2utm
+	$(INSTALL) -D -m 755 utm2ll $(DESTDIR)/bin/utm2ll
+	$(INSTALL) -D -m 755 aclients $(DESTDIR)/bin/aclients
+	$(INSTALL) -D -m 755 log2gpx $(DESTDIR)/bin/log2gpx
+	$(INSTALL) -D -m 755 gen_packets $(DESTDIR)/bin/gen_packets
+	$(INSTALL) -D -m 755 atest $(DESTDIR)/bin/atest
+	$(INSTALL) -D -m 755 ttcalc $(DESTDIR)/bin/ttcalc
+	$(INSTALL) -D -m 755 kissutil $(DESTDIR)/bin/kissutil
+	$(INSTALL) -D -m 755 dwespeak.sh $(DESTDIR)/bin/dwspeak.sh
+#
+# Telemetry Toolkit executables.   Other .conf and .txt files will go into doc directory.
+#
+	$(INSTALL) -D -m 755 telemetry-toolkit/telem-balloon.pl $(DESTDIR)/bin/telem-balloon.pl
+	$(INSTALL) -D -m 755 telemetry-toolkit/telem-bits.pl $(DESTDIR)/bin/telem-bits.pl
+	$(INSTALL) -D -m 755 telemetry-toolkit/telem-data.pl $(DESTDIR)/bin/telem-data.pl
+	$(INSTALL) -D -m 755 telemetry-toolkit/telem-data91.pl $(DESTDIR)/bin/telem-data91.pl
+	$(INSTALL) -D -m 755 telemetry-toolkit/telem-eqns.pl $(DESTDIR)/bin/telem-eqns.pl
+	$(INSTALL) -D -m 755 telemetry-toolkit/telem-parm.pl $(DESTDIR)/bin/telem-parm.pl
+	$(INSTALL) -D -m 755 telemetry-toolkit/telem-seq.sh $(DESTDIR)/bin/telem-seq.sh
+	$(INSTALL) -D -m 755 telemetry-toolkit/telem-unit.pl $(DESTDIR)/bin/telem-unit.pl
+	$(INSTALL) -D -m 755 telemetry-toolkit/telem-volts.py $(DESTDIR)/bin/telem-volts.py
+#
+# Misc. data such as "tocall" to system mapping.
+#
+	$(INSTALL) -D -m 644 tocalls.txt $(DESTDIR)/share/direwolf/tocalls.txt
+	$(INSTALL) -D -m 644 symbols-new.txt $(DESTDIR)/share/direwolf/symbols-new.txt
+	$(INSTALL) -D -m 644 symbolsX.txt $(DESTDIR)/share/direwolf/symbolsX.txt
+#
+# For desktop icon.
+#
+	$(INSTALL) -D -m 644 dw-icon.png $(DESTDIR)/share/direwolf/pixmaps/dw-icon.png
+	$(INSTALL) -D -m 644 direwolf.desktop $(DESTDIR)/share/applications/direwolf.desktop
+#
+# Documentation.  Various plain text files and PDF.
+#
+	$(INSTALL) -D -m 644 CHANGES.md $(DESTDIR)/share/doc/direwolf/CHANGES.md
+	$(INSTALL) -D -m 644 LICENSE-dire-wolf.txt $(DESTDIR)/share/doc/direwolf/LICENSE-dire-wolf.txt
+	$(INSTALL) -D -m 644 LICENSE-other.txt $(DESTDIR)/share/doc/direwolf/LICENSE-other.txt
+#
+# ./README.md is an overview for the project main page.
+# Maybe we could stick it in some other place.
+# doc/README.md contains an overview of the PDF file contents and is more useful here.
+#
+	$(INSTALL) -D -m 644 doc/README.md $(DESTDIR)/share/doc/direwolf/README.md
+	$(INSTALL) -D -m 644 doc/2400-4800-PSK-for-APRS-Packet-Radio.pdf $(DESTDIR)/share/doc/direwolf/2400-4800-PSK-for-APRS-Packet-Radio.pdf
+	$(INSTALL) -D -m 644 doc/A-Better-APRS-Packet-Demodulator-Part-1-1200-baud.pdf $(DESTDIR)/share/doc/direwolf/A-Better-APRS-Packet-Demodulator-Part-1-1200-baud.pdf
+	$(INSTALL) -D -m 644 doc/A-Better-APRS-Packet-Demodulator-Part-2-9600-baud.pdf $(DESTDIR)/share/doc/direwolf/A-Better-APRS-Packet-Demodulator-Part-2-9600-baud.pdf
+	$(INSTALL) -D -m 644 doc/A-Closer-Look-at-the-WA8LMF-TNC-Test-CD.pdf $(DESTDIR)/share/doc/direwolf/A-Closer-Look-at-the-WA8LMF-TNC-Test-CD.pdf
+	$(INSTALL) -D -m 644 doc/APRS-Telemetry-Toolkit.pdf $(DESTDIR)/share/doc/direwolf/APRS-Telemetry-Toolkit.pdf
+	$(INSTALL) -D -m 644 doc/APRStt-Implementation-Notes.pdf $(DESTDIR)/share/doc/direwolf/APRStt-Implementation-Notes.pdf
+	$(INSTALL) -D -m 644 doc/APRStt-interface-for-SARTrack.pdf $(DESTDIR)/share/doc/direwolf/APRStt-interface-for-SARTrack.pdf
+	$(INSTALL) -D -m 644 doc/APRStt-Listening-Example.pdf $(DESTDIR)/share/doc/direwolf/APRStt-Listening-Example.pdf
+	$(INSTALL) -D -m 644 doc/Bluetooth-KISS-TNC.pdf $(DESTDIR)/share/doc/direwolf/Bluetooth-KISS-TNC.pdf
+	$(INSTALL) -D -m 644 doc/Going-beyond-9600-baud.pdf $(DESTDIR)/share/doc/direwolf/Going-beyond-9600-baud.pdf
+	$(INSTALL) -D -m 644 doc/Raspberry-Pi-APRS.pdf $(DESTDIR)/share/doc/direwolf/Raspberry-Pi-APRS.pdf
+	$(INSTALL) -D -m 644 doc/Raspberry-Pi-APRS-Tracker.pdf $(DESTDIR)/share/doc/direwolf/Raspberry-Pi-APRS-Tracker.pdf
+	$(INSTALL) -D -m 644 doc/Raspberry-Pi-SDR-IGate.pdf $(DESTDIR)/share/doc/direwolf/Raspberry-Pi-SDR-IGate.pdf
+	$(INSTALL) -D -m 644 doc/Successful-APRS-IGate-Operation.pdf $(DESTDIR)/share/doc/direwolf/Successful-APRS-IGate-Operation.pdf
+	$(INSTALL) -D -m 644 doc/User-Guide.pdf $(DESTDIR)/share/doc/direwolf/User-Guide.pdf
+	$(INSTALL) -D -m 644 doc/WA8LMF-TNC-Test-CD-Results.pdf $(DESTDIR)/share/doc/direwolf/WA8LMF-TNC-Test-CD-Results.pdf
+#
+# Various sample config and other files go into examples under the doc directory.
+# When building from source, these can be put in home directory with "make install-conf".
+# When installed from .DEB or .RPM package, the user will need to copy these to
+# the home directory or other desired location.
+#
+	$(INSTALL) -D -m 644 direwolf.conf $(DESTDIR)/share/doc/direwolf/examples/direwolf.conf
+	$(INSTALL) -D -m 755 dw-start.sh $(DESTDIR)/share/doc/direwolf/examples/dw-start.sh
+	$(INSTALL) -D -m 644 sdr.conf $(DESTDIR)/share/doc/direwolf/examples/sdr.conf
+	$(INSTALL) -D -m 644 telemetry-toolkit/telem-m0xer-3.txt $(DESTDIR)/share/doc/direwolf/examples/telem-m0xer-3.txt
+	$(INSTALL) -D -m 644 telemetry-toolkit/telem-balloon.conf $(DESTDIR)/share/doc/direwolf/examples/telem-balloon.conf
+	$(INSTALL) -D -m 644 telemetry-toolkit/telem-volts.conf $(DESTDIR)/share/doc/direwolf/examples/telem-volts.conf
+#
+# "man" pages
+#
+	$(INSTALL) -D -m 644 man1/aclients.1 $(DESTDIR)/share/man/man1/aclients.1
+	$(INSTALL) -D -m 644 man1/atest.1 $(DESTDIR)/share/man/man1/atest.1
+	$(INSTALL) -D -m 644 man1/decode_aprs.1 $(DESTDIR)/share/man/man1/decode_aprs.1
+	$(INSTALL) -D -m 644 man1/direwolf.1 $(DESTDIR)/share/man/man1/direwolf.1
+	$(INSTALL) -D -m 644 man1/gen_packets.1 $(DESTDIR)/share/man/man1/gen_packets.1
+	$(INSTALL) -D -m 644 man1/kissutil.1 $(DESTDIR)/share/man/man1/kissutil.1
+	$(INSTALL) -D -m 644 man1/ll2utm.1 $(DESTDIR)/share/man/man1/ll2utm.1
+	$(INSTALL) -D -m 644 man1/log2gpx.1 $(DESTDIR)/share/man/man1/log2gpx.1
+	$(INSTALL) -D -m 644 man1/text2tt.1 $(DESTDIR)/share/man/man1/text2tt.1
+	$(INSTALL) -D -m 644 man1/tt2text.1 $(DESTDIR)/share/man/man1/tt2text.1
+	$(INSTALL) -D -m 644 man1/utm2ll.1 $(DESTDIR)/share/man/man1/utm2ll.1
+#
+	@echo " "
+	@echo "If this is your first install, not an upgrade, type this to put a copy"
+	@echo "of the sample configuration file (direwolf.conf) in your home directory:"
+	@echo " "
+	@echo "        $(MAKE) install-conf"
+	@echo " "
+
+
+# Put sample configuration & startup files in home directory.
+# This step would be done as ordinary user.
+# Some people like to put the direwolf config file in /etc/ax25.
+# Note that all of these are also in $(DESTDIR)/share/doc/direwolf/examples/.
+
+# The Raspberry Pi has ~/Desktop but Ubuntu does not.
+
+# TODO: Handle Linux variations correctly.
+
+# Version 1.4 - Add "-i" option to avoid clobbering existing, probably customized, config files.
+
+# dw-start.sh is greatly improved in version 1.4.
+# It was moved from isntall-rpi to install-conf because it is not just for the RPi.
+
+.PHONY: install-conf
+install-conf : direwolf.conf
+	cp -i direwolf.conf ~
+	cp -i sdr.conf ~
+	cp -i telemetry-toolkit/telem-m0xer-3.txt ~
+	cp -i telemetry-toolkit/telem-*.conf ~
+	chmod +x dw-start.sh
+	cp -i dw-start.sh ~
+ifneq ($(wildcard $(HOME)/Desktop),)
+	@echo " "
+	@echo "This will add a desktop icon on some systems."
+	@echo "This is known to work on Raspberry Pi but might not be compatible with other desktops."
+	@echo " "
+	@echo "        $(MAKE) install-rpi"
+	@echo " "
+endif
+
+
+.PHONY: install-rpi
+install-rpi : 
+	ln -f -s $(DESTDIR)/share/applications/direwolf.desktop ~/Desktop/direwolf.desktop
+
+
+
+# ----------------------------------  Automated Smoke Test  --------------------------------
+
+
+
+# Combine some unit tests into a single regression sanity check.
+
+
+check : dtest ttest tttexttest pftest tlmtest lltest enctest kisstest pad2test xidtest dtmftest check-modem1200 check-modem300 check-modem9600 check-modem19200 check-modem2400 check-modem4800
+
+# Can we encode and decode at popular data rates?
+
+check-modem1200 : gen_packets atest
+	./gen_packets -n 100 -o /tmp/test12.wav
+	./atest -F0 -PE -L63 -G71 /tmp/test12.wav
+	./atest -F1 -PE -L70 -G75 /tmp/test12.wav
+	rm /tmp/test12.wav
+
+check-modem300 : gen_packets atest
+	./gen_packets -B300 -n 100 -o /tmp/test3.wav
+	./atest -B300 -F0 -L68 -G69 /tmp/test3.wav
+	./atest -B300 -F1 -L73 -G75 /tmp/test3.wav
+	rm /tmp/test3.wav
+
+check-modem9600 : gen_packets atest
+	./gen_packets -B9600 -n 100 -o /tmp/test96.wav
+	./atest -B9600 -F0 -L50 -G54 /tmp/test96.wav
+	./atest -B9600 -F1 -L55 -G59 /tmp/test96.wav
+	rm /tmp/test96.wav
+
+check-modem19200 : gen_packets atest
+	./gen_packets -r 96000 -B19200 -n 100 -o /tmp/test19.wav
+	./atest -B19200 -F0 -L55 -G59 /tmp/test19.wav
+	./atest -B19200 -F1 -L60 -G64 /tmp/test19.wav
+	rm /tmp/test19.wav
+
+check-modem2400 : gen_packets atest
+	./gen_packets -B2400 -n 100 -o /tmp/test24.wav
+	./atest -B2400 -F0 -L70 -G78 /tmp/test24.wav
+	./atest -B2400 -F1 -L80 -G87 /tmp/test24.wav
+	rm /tmp/test24.wav
+
+check-modem4800 : gen_packets atest
+	./gen_packets -B2400 -n 100 -o /tmp/test48.wav
+	./atest -B2400 -F0 -L70 -G79 /tmp/test48.wav
+	./atest -B2400 -F1 -L80 -G90 /tmp/test48.wav
+	rm /tmp/test48.wav
+
+
+# Unit test for inner digipeater algorithm
+
+.PHONY : dtest
+dtest : digipeater.c dedupe.c pfilter.c \
+		ax25_pad.o fcs_calc.o tq.o textcolor.o \
+		decode_aprs.o dwgpsnmea.o dwgps.o dwgpsd.o serial_port.o latlong.o telemetry.o symbols.o tt_text.o misc.a
+	$(CC) $(CFLAGS) -DDIGITEST -o $@ $^ $(LDFLAGS)
+	./dtest
+	rm dtest
+
+
+# Unit test for APRStt tone sequence parsing.
+
+.PHONY : ttest
+ttest : aprs_tt.c tt_text.c latlong.o textcolor.o misc.a geotranz.a misc.a
+	$(CC) $(CFLAGS) -DTT_MAIN  -o $@ $^ $(LDFLAGS)
+	./ttest
+	rm ttest
+
+
+# Unit test for APRStt tone sequence / text conversions.
+
+.PHONY: tttexttest
+tttexttest : tt_text.c textcolor.o misc.a
+	$(CC) $(CFLAGS) -DTTT_TEST -o $@ $^ $(LDFLAGS)
+	./tttexttest
+	rm tttexttest
+
+
+# Unit test for Packet Filtering.
+
+.PHONY: pftest
+pftest : pfilter.c ax25_pad.o textcolor.o fcs_calc.o decode_aprs.o dwgpsnmea.o dwgps.o dwgpsd.o serial_port.o latlong.o symbols.o telemetry.o tt_text.o misc.a 
+	$(CC) $(CFLAGS) -DPFTEST -o $@ $^ $(LDFLAGS)
+	./pftest
+	rm pftest
+
+# Unit test for telemetry decoding.
+
+.PHONY: tlmtest
+tlmtest : telemetry.c ax25_pad.o fcs_calc.o textcolor.o misc.a
+	$(CC) $(CFLAGS) -DTEST -o $@ $^ $(LDFLAGS)
+	./tlmtest
+	rm tlmtest
+
+# Unit test for location coordinate conversion.
+
+.PHONY: lltest
+lltest : latlong.c textcolor.o misc.a
+	$(CC) $(CFLAGS) -DLLTEST -o $@ $^ $(LDFLAGS)
+	./lltest
+	rm lltest
+
+# Unit test for encoding position & object report.
+
+.PHONY: enctest
+enctest : encode_aprs.c latlong.c textcolor.c misc.a
+	$(CC) $(CFLAGS) -DEN_MAIN -o $@ $^ $(LDFLAGS)
+	./enctest
+	rm enctest
+
+
+# Unit test for KISS encapsulation.
+
+.PHONY: kisstest
+kisstest : kiss_frame.c
+	$(CC) $(CFLAGS) -DKISSTEST -o $@ $^ $(LDFLAGS)
+	./kisstest
+	rm kisstest
+
+# Unit test for constructing frames besides UI.
+
+.PHONY: pad2test
+pad2test : ax25_pad2.c ax25_pad.c fcs_calc.o textcolor.o misc.a
+	$(CC) $(CFLAGS) -DPAD2TEST -o $@ $^ $(LDFLAGS)
+	./pad2test
+	rm pad2test
+
+
+# Unit Test for XID frame encode/decode.
+
+.PHONY: xidtest
+xidtest : xid.c textcolor.o misc.a
+	$(CC) $(CFLAGS) -DXIDTEST -o $@ $^  $(LDFLAGS)
+	./xidtest
+	rm xidtest
+
+
+# Unit Test for DTMF encode/decode.
+
+.PHONY: dtmftest
+dtmftest : dtmf.c textcolor.o
+	$(CC) $(CFLAGS) -DDTMF_TEST -o $@ $^  $(LDFLAGS)
+	./dtmftest
+	rm dtmftest
+
+
+
+#  -----------------------------  Manual tests and experiments  ---------------------------
+
+# These are not included in a normal build.  Might be broken.
+
+# Unit test for IGate
+
+itest : igate.c textcolor.c ax25_pad.c fcs_calc.c textcolor.o misc.a
+	$(CC) $(CFLAGS) -DITEST -o $@ $^
+	./itest
+
+# Unit test for UDP reception with AFSK demodulator.
+# Temporary during development.  Might not be useful anymore.
+
+udptest : udp_test.c demod.o dsp.o demod_afsk.o demod_psk.o demod_9600.o hdlc_rec.o hdlc_rec2.o multi_modem.o rrbb.o \
+		fcs_calc.o ax25_pad.o decode_aprs.o symbols.o textcolor.o misc.a
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	./udptest
+
+# For demodulator tweaking experiments.
+# Dependencies of demod*.c, rather than .o, are intentional.
+
+demod.o      : tune.h
+
+demod_afsk.o : tune.h
+
+demod_9600.o : tune.h
+
+demod_psk.o  : tune.h
+
+tune.h :
+	echo " " > tune.h
+
+
+testagc : atest.c demod.c dsp.c demod_afsk.c demod_psk.c demod_9600.c hdlc_rec.o hdlc_rec2.o multi_modem.o rrbb.o \
+		fcs_calc.o ax25_pad.o decode_aprs.o telemetry.o dtime_now.o latlong.o symbols.o tune.h textcolor.o misc.a
+	$(CC) $(CFLAGS) -o atest $^ $(LDFLAGS)
+	./atest 02_Track_2.wav | grep "packets decoded in" > atest.out
+
+
+testagc96 : atest.c fsk_fast_filter.h tune.h demod.c demod_afsk.c demod_psk.c demod_9600.c \
+		dsp.o hdlc_rec.o hdlc_rec2.o multi_modem.o \
+		rrbb.o fcs_calc.o ax25_pad.o decode_aprs.o \
+		dwgpsnmea.o dwgps.o dwgpsd.o serial_port.o latlong.o \
+		symbols.o tt_text.o textcolor.o telemetry.o dtime_now.o \
+		misc.a
+	rm -f atest96
+	$(CC) $(CFLAGS) -o atest96 $^ $(LDFLAGS)
+	./atest96 -B 9600 ../walkabout9600c.wav | grep "packets decoded in" >atest.out
+	#./atest96 -B 9600 noisy96.wav | grep "packets decoded in" >atest.out
+	#./atest96 -B 9600 19990303_0225_9600_8bis_22kHz.wav | grep "packets decoded in" >atest.out
+	#./atest96 -B 9600  19990303_0225_9600_16bit_22kHz.wav | grep "packets decoded in" >atest.out
+	#./atest96 -B 9600 -P + z8-22k.wav| grep "packets decoded in" >atest.out
+	#./atest96 -B 9600 test9600.wav | grep "packets decoded in" >atest.out
+	echo " " > tune.h
+
+
+
+
+# -------------------------------   Source distribution  ---------------------------------
+
+# probably obsolete and can be removed after move to github.
+
+
+
+.PHONY: dist-src
+dist-src : README.md CHANGES.md 
+		doc/User-Guide.pdf doc/Raspberry-Pi-APRS.pdf \
+		doc/Raspberry-Pi-APRS-Tracker.pdf doc/APRStt-Implementation-Notes.pdf \
+		dw-start.sh dwespeak.bat dwespeak.sh \
+		tocalls.txt symbols-new.txt symbolsX.txt direwolf.spec
+	rm -f fsk_fast_filter.h
+	echo " " > tune.h
+	rm -f ../$z-src.zip
+	(cd .. ; zip $z-src.zip \
+		$z/README.md \
+		$z/CHANGES.md \
+		$z/LICENSE* \
+		$z/doc/User-Guide.pdf \
+		$z/doc/Raspberry-Pi-APRS.pdf \
+		$z/doc/Raspberry-Pi-APRS-Tracker.pdf \
+		$z/doc/APRStt-Implementation-Notes.pdf \
+		$z/doc/APRS-Telemetry-Toolkit.pdf \
+		$z/Makefile* \
+		$z/*.c $z/*.h \
+		$z/regex/* $z/misc/* $z/geotranz/* \
+		$z/man1/* \
+		$z/generic.conf \
+		$z/tocalls.txt $z/symbols-new.txt $z/symbolsX.txt \
+		$z/dw-icon.png $z/dw-icon.rc $z/dw-icon.ico \
+		$z/dw-start.sh $z/direwolf.spec \
+		$z/dwespeak.bat $z/dwespeak.sh \
+		$z/telemetry-toolkit/* )
+		
+
+# -----------------------------------------------------------------------------------------
+
+
+.PHONY: clean
+clean :
+	rm -f $(APPS) gen_fff tune.h fsk_fast_filter.h *.o *.a direwolf.desktop direwolf.conf
+
+
+depend : $(wildcard *.c)
+	makedepend -f $(lastword $(MAKEFILE_LIST)) -- $(CFLAGS) -- $^
+
+
+#
+# The following is updated by "make depend"
+#
+# DO NOT DELETE
+
+

--- a/audio.h
+++ b/audio.h
@@ -302,12 +302,12 @@ struct audio_s {
 
 #if __WIN32__ || __APPLE__
 #define DEFAULT_ADEVICE	""		/* Windows: Empty string = default audio device. */
-#else
-#if USE_ALSA
+#elif USE_ALSA
 #define DEFAULT_ADEVICE	"default"	/* Use default device for ALSA. */
+#elif __OpenBSD__
+#define DEFAULT_ADEVICE	"default"	/* Use default device for OpenBSD-portaudio. */
 #else
 #define DEFAULT_ADEVICE	"/dev/dsp"	/* First audio device for OSS. */
-#endif					
 #endif
 
 

--- a/dw-start.sh
+++ b/dw-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run this from crontab periodically to start up
 # Dire Wolf automatically.

--- a/kissutil.c
+++ b/kissutil.c
@@ -46,7 +46,11 @@
 #else 
 
 #include <stdlib.h>
+#ifdef __OpenBSD__
+#include <errno.h>
+#else
 #include <sys/errno.h>
+#endif
 #include <sys/types.h>
 #include <sys/socket.h>
 


### PR DESCRIPTION
Simply add Makefile.openbsd and modified some stuffs.

The difference from Linux:

- use PortAudio as default to support sndio interface
- no CM108 GPIO support

On OpenBSD, the path to bash is /usr/local/bin/bash not /bin/bash
so dw-start.sh needs to support both paths.