### PR TITLE
Add build option for udev path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,9 @@ else()
   set(INSTALL_SCRIPTS_DIR "${INSTALL_DOC_DIR}/scripts")
   set(INSTALL_MAN_DIR "share/man/man1")
   set(INSTALL_DATA_DIR "share/${PROJECT_NAME}")
+  if (NOT DEFINED UDEV_RULES_DIR OR "${UDEV_RULES_DIR}" STREQUAL "")
+    set(UDEV_RULES_DIR "/etc/udev/rules.d")
+  endif()
 endif(WIN32 OR CYGWIN)
 
 # requirements

--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -26,7 +26,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/direwolf.conf" "${file_content}")
 
 # install udev rules for CM108
 if(LINUX)
-  install(FILES "${CUSTOM_CONF_DIR}/99-direwolf-cmedia.rules" DESTINATION /etc/udev/rules.d/)
+  install(FILES "${CUSTOM_CONF_DIR}/99-direwolf-cmedia.rules" DESTINATION ${UDEV_RULES_DIR})
 endif()
 
 install(FILES "${CMAKE_BINARY_DIR}/direwolf.conf" DESTINATION ${INSTALL_CONF_DIR})


### PR DESCRIPTION
The path for the udev rules is currently hardcoded, which requires a patch to package on some distributions (e.g. Arch Linux).