### PR TITLE
Update direwolf.h

### DIFF
--- a/src/direwolf.h
+++ b/src/direwolf.h
@@ -37,6 +37,7 @@
 
 #endif
 
+#include <stddef.h>
 
 /*
  * Previously, we could handle only a single audio device.


### PR DESCRIPTION
Fix the following errors during compile.

note: ‘ptrdiff_t’ is defined in header ‘<stddef.h>’; did you forget to ‘#include <stddef.h>’?