### PR TITLE
Include <stddef.h> everywhere ptrdiff_t is used

### DIFF
--- a/src/aclients.c
+++ b/src/aclients.c
@@ -76,6 +76,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <ctype.h>
+#include <stddef.h>
 #include <string.h>
 #include <time.h>
 

--- a/src/dwgpsd.c
+++ b/src/dwgpsd.c
@@ -45,6 +45,7 @@
 #include <errno.h>
 #include <time.h>
 #include <math.h>
+#include <stddef.h>
 
 #if __WIN32__
 #error Not for Windows

--- a/src/dwgpsnmea.c
+++ b/src/dwgpsnmea.c
@@ -54,6 +54,7 @@
 #include <string.h>
 #include <errno.h>
 #include <time.h>
+#include <stddef.h>
 
 
 #include "textcolor.h"

--- a/src/kissnet.c
+++ b/src/kissnet.c
@@ -113,6 +113,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <stddef.h>
 
 
 #include "tq.h"

--- a/src/kissutil.c
+++ b/src/kissutil.c
@@ -56,6 +56,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <ctype.h>
+#include <stddef.h>
 #include <string.h>
 #include <getopt.h>
 #include <dirent.h>

--- a/src/recv.c
+++ b/src/recv.c
@@ -88,6 +88,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stddef.h>
 #include <sys/types.h>
 //#include <sys/stat.h>
 //#include <sys/ioctl.h>

--- a/src/server.c
+++ b/src/server.c
@@ -145,6 +145,7 @@
 #include <string.h>
 #include <time.h>
 #include <ctype.h>
+#include <stddef.h>
 
 #include "tq.h"
 #include "ax25_pad.h"

--- a/src/xmit.c
+++ b/src/xmit.c
@@ -60,6 +60,7 @@
 #include <string.h>
 #include <math.h>
 #include <errno.h>
+#include <stddef.h>
 
 #include "direwolf.h"
 #include "ax25_pad.h"


### PR DESCRIPTION
ptrdiff_t is defined in <stddef.h>