### PR TITLE
Make udev rules obey $DESTDIR on Linux

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -680,7 +680,7 @@ install : $(APPS) direwolf.conf tocalls.txt symbols-new.txt symbolsX.txt dw-icon
 # Set group and mode of HID devices corresponding to C-Media USB Audio adapters.
 # This will allow us to use the CM108/CM119 GPIO pins for PTT.
 #
-	$(INSTALL) -D --mode=644 99-direwolf-cmedia.rules /etc/udev/rules.d/99-direwolf-cmedia.rules
+	$(INSTALL) -D --mode=644 99-direwolf-cmedia.rules $(DESTDIR)/etc/udev/rules.d/99-direwolf-cmedia.rules
 #
 	@echo " "
 	@echo "If this is your first install, not an upgrade, type this to put a copy"


### PR DESCRIPTION
When packaging this on Linux, we build into a subdirectory using $DESTDIR. Other than what's in install-conf, which can be skipped during building a package, this is the last piece that didn't obey $DESTDIR.