### PR TITLE
Add Github action for x86_64 Linux build

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,17 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build-ubuntu:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: update
+      run: sudo apt update && sudo apt-get install libasound2-dev
+    - name: configure
+      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Werror" ..
+    - name: build
+      run: cmake --build build


### PR DESCRIPTION
It will trigger a build every time you push code. It should be easy to add support for macOS and Windows later.