### PR TITLE
Check for ntp clock shift when scheduling next beacon. 

### DIFF
--- a/src/beacon.c
+++ b/src/beacon.c
@@ -614,6 +614,14 @@ static void * beacon_thread (void *arg)
 	        /* i.e. Don't take relative to now in case there was some delay. */
 
 	        bp->next += bp->every;
+
+                /* craigerl: if next beacon is scheduled in the past, then set next beacon relative to now (happens when NTP pushes clock AHEAD) */
+                /* fixme: if NTP sets clock BACK an hour, this thread will sleep for that hour */
+                if ( bp->next < now ) {
+                    bp->next = now + bp->every;
+                    dw_printf("\nSystem clock appears to have jumped forward.  Beacon schedule updated.\n\n");
+                }
+
 	      }
 
 	    }  /* if time to send it */


### PR DESCRIPTION
See  https://github.com/wb2osz/direwolf/issues/206 for details and logs.

According to beacon.c, if the system clock shifts forward, direwolf will emit all the pbeacons it missed during that interval all at once, until it's caught up. For example, if the internet is unavailable during boot, ntp cannot update the system time. Direwolf then starts, the internet becomes available, and ntp shifts the clock foward three hours. If direwolf is configured to send a pbeacon every 20 minutes, it will quickly send nine consecutive pbeacons (observed).

beacon.c is where the bug exists. Pbeacons should, in fact, be relative to "now" if the system clock shifted forward.  If the next scheduled beacon is in the past, then set it relative to the new now. This prevents all  the catchup beacons after a system time change.

On a raspberry pi with a read-only filesystem, the NTP jump can be months, effectively jamming the transmitter on for  hours.  (observed)

