### PR TITLE
Added handling of serial port DCB for Windows

### DIFF
--- a/src/ptt.c
+++ b/src/ptt.c
@@ -180,17 +180,51 @@ typedef int HANDLE;
 
 #if __WIN32__
 
-#define RTS_ON(fd) 	EscapeCommFunction(fd,SETRTS);
-#define RTS_OFF(fd) 	EscapeCommFunction(fd,CLRRTS);
-#define DTR_ON(fd)    	EscapeCommFunction(fd,SETDTR);
-#define DTR_OFF(fd)	EscapeCommFunction(fd,CLRDTR);
+void setRTS(HANDLE fd, unsigned char state)
+{
+	if (!EscapeCommFunction(fd, state ? SETRTS : CLRRTS)) {
+		return;
+	}
+
+	DCB dcb;
+	if (!GetCommState(fd, &dcb)) {
+		return;
+	}
+
+	dcb.fRtsControl = state ? RTS_CONTROL_ENABLE : RTS_CONTROL_DISABLE;
+
+	SetCommState(fd, &dcb);
+}
+
+void setDTR(HANDLE fd, unsigned char state)
+{
+	if (!EscapeCommFunction(fd, state ? SETDTR : CLRDTR)) {
+		return;
+	}
+
+	DCB dcb;
+	if (!GetCommState(fd, &dcb)) {
+		return;
+	}
+
+	dcb.fDtrControl = state ? DTR_CONTROL_ENABLE : DTR_CONTROL_DISABLE;
+
+	SetCommState(fd, &dcb);
+}
 
 #else
 
-#define RTS_ON(fd) 	{ int stuff; ioctl (fd, TIOCMGET, &stuff); stuff |= TIOCM_RTS;  ioctl (fd, TIOCMSET, &stuff); }
-#define RTS_OFF(fd) 	{ int stuff; ioctl (fd, TIOCMGET, &stuff); stuff &= ~TIOCM_RTS; ioctl (fd, TIOCMSET, &stuff); }
-#define DTR_ON(fd)    	{ int stuff; ioctl (fd, TIOCMGET, &stuff); stuff |= TIOCM_DTR;  ioctl (fd, TIOCMSET, &stuff); }
-#define DTR_OFF(fd)	{ int stuff; ioctl (fd, TIOCMGET, &stuff); stuff &= ~TIOCM_DTR;	ioctl (fd, TIOCMSET, &stuff); }
+void setRTS(HANDLE fd, unsigned char state)
+{
+	int bit = TIOCM_RTS;
+	ioctl(fd, state ? TIOCMBIS : TIOCMBIC, &bit);
+}
+
+void setDTR(HANDLE fd, unsigned char state)
+{
+	int bit = TIOCM_DTR;
+	ioctl(fd, state ? TIOCMBIS : TIOCMBIC, &bit);
+}
 
 #define LPT_IO_ADDR 0x378
 
@@ -1182,21 +1216,11 @@ void ptt_set (int ot, int chan, int ptt_signal)
 
 	  if (save_audio_config_p->achan[chan].octrl[ot].ptt_line == PTT_LINE_RTS) {
 
-	    if (ptt) {
-	      RTS_ON(ptt_fd[chan][ot]);
-	    }
-	    else {
-	      RTS_OFF(ptt_fd[chan][ot]);
-	    }
+	    setRTS(ptt_fd[chan][ot], ptt);
 	  }
 	  else if (save_audio_config_p->achan[chan].octrl[ot].ptt_line == PTT_LINE_DTR) {
 
-	    if (ptt) {
-	      DTR_ON(ptt_fd[chan][ot]);
-	    }
-	    else {
-	      DTR_OFF(ptt_fd[chan][ot]);
-	    }
+	    setDTR(ptt_fd[chan][ot], ptt);
 	  }
 
 /* 
@@ -1205,21 +1229,11 @@ void ptt_set (int ot, int chan, int ptt_signal)
 
 	  if (save_audio_config_p->achan[chan].octrl[ot].ptt_line2 == PTT_LINE_RTS) {
 
-	    if (ptt2) {
-	      RTS_ON(ptt_fd[chan][ot]);
-	    }
-	    else {
-	      RTS_OFF(ptt_fd[chan][ot]);
-	    }
+	    setRTS(ptt_fd[chan][ot], ptt2);
 	  }
 	  else if (save_audio_config_p->achan[chan].octrl[ot].ptt_line2 == PTT_LINE_DTR) {
 
-	    if (ptt2) {
-	      DTR_ON(ptt_fd[chan][ot]);
-	    }
-	    else {
-	      DTR_OFF(ptt_fd[chan][ot]);
-	    }
+		setDTR(ptt_fd[chan][ot], ptt2);
 	  }
 	  /* else neither one */
 


### PR DESCRIPTION
Fix for issue #315 

On Windows systems, it seems to depend on the driver resp. serial port hardware if a simple call of `EscapeCommFunction()` is enough. If the fDtrControl or fRtsControl in the DCB is in the wrong state, it may fail to set it as desired.
see [https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-dcb#members](https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-dcb#members)

Furthermore, I've tried to simplify the Linux version which allows to directly set/clear the bits with the `ioctl()` function, according to [https://linux.die.net/man/4/tty_ioctl](https://linux.die.net/man/4/tty_ioctl)