### PR TITLE
Windows re_syntax_options

### DIFF
--- a/external/regex/CMakeLists.txt
+++ b/external/regex/CMakeLists.txt
@@ -18,7 +18,7 @@ if(WIN32 OR CYGWIN) # windows
     )
 
   set_target_properties(regex
-    PROPERTIES COMPILE_FLAGS "-Dbool=int -Dtrue=1 -Dfalse=0 -DUSE_REGEX_STATIC"
+    PROPERTIES COMPILE_FLAGS "-Dbool=int -Dtrue=1 -Dfalse=0 -DREGEX_STATIC"
     )
 
 endif()

--- a/external/regex/regex.h
+++ b/external/regex/regex.h
@@ -35,17 +35,23 @@
 #if (defined __WIN32__) || (defined _WIN32)
 # ifdef BUILD_REGEX_DLL
 #  define REGEX_DLL_IMPEXP	__DLL_EXPORT__
+#  define REGEX_VARIABLE_IMPEXP	__DLL_EXPORT__
 # elif defined(REGEX_STATIC)
 #  define REGEX_DLL_IMPEXP	 
+#  define REGEX_VARIABLE_IMPEXP
 # elif defined (USE_REGEX_DLL)
 #  define REGEX_DLL_IMPEXP	__DLL_IMPORT__
+#  define REGEX_VARIABLE_IMPEXP	__DLL_IMPORT__
 # elif defined (USE_REGEX_STATIC)
 #  define REGEX_DLL_IMPEXP 	 
+#  define REGEX_VARIABLE_IMPEXP	extern
 # else /* assume USE_REGEX_DLL */
 #  define REGEX_DLL_IMPEXP	__DLL_IMPORT__
+#  define REGEX_VARIABLE_IMPEXP	__DLL_IMPORT__
 # endif
 #else /* __WIN32__ */
 # define REGEX_DLL_IMPEXP	 
+# define REGEX_VARIABLE_IMPEXP
 #endif
 
 /* Allow the use in C++ code.  */
@@ -202,7 +208,7 @@ typedef unsigned long int reg_syntax_t;
    some interfaces).  When a regexp is compiled, the syntax used is
    stored in the pattern buffer, so changing this does not affect
    already-compiled regexps.  */
-REGEX_DLL_IMPEXP reg_syntax_t re_syntax_options;
+REGEX_VARIABLE_IMPEXP reg_syntax_t re_syntax_options;
 
 /* Define combinations of the above bits for the standard possibilities.
    (The [[[ comments delimit what gets put into the Texinfo file, so


### PR DESCRIPTION
When building regex for Windows, don't repeatedly define the global variable re_syntax_options.