### PR TITLE
Windows USE_CM108

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,8 @@ else()
   set(ALSA_LIBRARIES "")
   set(UDEV_INCLUDE_DIRS "")
   set(UDEV_LIBRARIES "")
+  # Version 1.7 supports CM108/CM119 GPIO PTT for Windows.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_CM108")
   set(PORTAUDIO_INCLUDE_DIRS "")
   set(PORTAUDIO_LIBRARIES "")
 endif()

--- a/src/direwolf.h
+++ b/src/direwolf.h
@@ -37,13 +37,6 @@
 
 #endif
 
-// Version 1.7 supports CM108/CM119 GPIO PTT for Windows.
-// Define it here so we don't need to have separate Windows
-// check in all the places that test this.
-#if __WIN32__
-#define USE_CM108 1
-#endif
-
 /*
  * Previously, we could handle only a single audio device.
  * This meant we could have only two radio channels.

--- a/src/ptt.c
+++ b/src/ptt.c
@@ -162,15 +162,15 @@
 #include <hamlib/rig.h>
 #endif
 
-#ifdef USE_CM108
-#include "cm108.h"
-#endif
-
 /* So we can have more common code for fd. */
 typedef int HANDLE;
 #define INVALID_HANDLE_VALUE (-1)
 
-#endif
+#endif /* __WIN32__ */
+
+#ifdef USE_CM108
+#include "cm108.h"
+#endif /* USE_CM108 */
 
 #include "textcolor.h"
 #include "audio.h"


### PR DESCRIPTION
When building for Windows, declare cm108_set_gpio_pin explicitly in cm108.h (not implicitly in ptt.c).