### PR TITLE
Fix/typos

### DIFF
--- a/src/appserver.c
+++ b/src/appserver.c
@@ -320,7 +320,7 @@ static void poll_timing_test (void)
  *
  *		data		- Should look something like this for incoming:
  *					*** CONNECTED to Station xxx\r
- *				  and ths for my request being accepted:
+ *				  and this for my request being accepted:
  *					*** CONNECTED With Station xxx\r
  *
  *		session_id	- Session id to be used in data transfer and

--- a/src/audio.c
+++ b/src/audio.c
@@ -821,7 +821,7 @@ static int poll_sndio (struct sio_hdl *hdl, int events)
 	  revents = sio_revents (hdl, pfds);
 	} while (!(revents & (events | POLLHUP)));
 
-	/* unrecoverable error occured */
+	/* unrecoverable error occurred */
 	if (revents & POLLHUP) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("waited for %s, POLLHUP received\n", (events & POLLIN) ? "POLLIN" : "POLLOUT");

--- a/src/cm108.c
+++ b/src/cm108.c
@@ -854,7 +854,7 @@ void cm108_find_ptt (char *output_audio_device, char *ptt_device,  int ptt_devic
  *
  * Future:	For our initial implementation we are making the simplifying
  *		restriction of using only one GPIO pin per device and limit
- *		configuratin to PTT only.
+ *		configuration to PTT only.
  *		Longer term, we might want to have DCD, and maybe other
  *		controls thru the same chip.
  *		In this case, we would need to retain bit masks for each

--- a/src/cm108.c
+++ b/src/cm108.c
@@ -304,7 +304,7 @@ static void usage(void)
 	dw_printf ("which ones can be used for GPIO PTT.\n");
 #endif
 	dw_printf ("\n");
-	dw_printf ("Specify the HID device path to test the PTT fuction.\n");
+	dw_printf ("Specify the HID device path to test the PTT function.\n");
 	dw_printf ("Its state should change once per second.\n");
 #if __WIN32__
 	dw_printf ("You might need to quote the path depending on the command processor.\n");

--- a/src/demod_afsk.c
+++ b/src/demod_afsk.c
@@ -582,7 +582,7 @@ void demod_afsk_init (int samples_per_sec, int baud, int mark_freq,
  *
  * First, let's take a look at Track 1 of the TNC test CD.  Here the receiver
  * has a flat response.  We find the mark/space strength ratios very from 0.53 to 1.38
- * with a median of 0.81.  This in in line with expections because most
+ * with a median of 0.81.  This in in line with expectations because most
  * transmitters add pre-emphasis to boost the higher audio frequencies.
  * Track 2 should more closely resemble what comes out of the speaker on a typical
  * transceiver.  Here we see a ratio from 1.73 to 3.81 with a median of 2.48.
@@ -700,7 +700,7 @@ void demod_afsk_process_sample (int chan, int subchan, int sam, struct demodulat
 	      // Rather than trying to find the best threshold location, use multiple 
 	      // slicer thresholds in parallel.
 	      // The best slicing point will vary from packet to packet but should
-	      // remain abount the same or a given packet.
+	      // remain about the same for a given packet.
 
 	      // We are not performing the AGC step here but still want the envelope
 	      // for caluculating the confidence level (or quality) of the sample.

--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -382,7 +382,7 @@ int main (int argc, char *argv[])
 	if (getuid() == 0 || geteuid() == 0) {
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("Dire Wolf requires only privileges available to ordinary users.\n");
-	    dw_printf ("Running this as root is an unnecssary security risk.\n");
+	    dw_printf ("Running this as root is an unnecessary security risk.\n");
 	}
 #endif
 

--- a/src/dns_sd_avahi.c
+++ b/src/dns_sd_avahi.c
@@ -241,7 +241,7 @@ void dns_sd_announce (struct misc_config_s *mc)
         /* Allocate a new client */
         client = avahi_client_new(avahi_simple_poll_get(simple_poll), 0, client_callback, NULL, &error);
 
-        /* Check wether creating the client object succeeded */
+        /* Check whether creating the client object succeeded */
         if (!client) {
             text_color_set(DW_COLOR_ERROR);
             dw_printf(PRINT_PREFIX "Failed to create Avahi client: %s\n", avahi_strerror(error));

--- a/src/dwgpsnmea.c
+++ b/src/dwgpsnmea.c
@@ -628,7 +628,7 @@ dwfix_t dwgpsnmea_gpgga (char *sentence, int quiet, double *odlat, double *odlon
 	char *pew;			/* East/West */
 	char *pfix;			/* 0=invalid, 1=GPS fix, 2=DGPS fix */
 	char *pnum_sat;			/* Number of satellites */
-	char *phdop;			/* Horiz. Dilution fo Precision */
+	char *phdop;			/* Horiz. Dilution of Precision */
 	char *paltitude;		/* Altitude, above mean sea level */
 	char *palt_u;			/* Units for Altitude, typically M for meters. */
 	char *pheight;			/* Height above ellipsoid */

--- a/src/encode_aprs.c
+++ b/src/encode_aprs.c
@@ -125,7 +125,7 @@ static int set_norm_position (char symtab, char symbol, double dlat, double dlon
  *		height	- Feet.
  *		gain	- dBi.
  *
- * 		course	- Degress, 0 - 360 (360 equiv. to 0).  
+ * 		course	- Degrees, 0 - 360 (360 equiv. to 0).
  *			  Use G_UNKNOWN for none or unknown.
  *		speed	- knots.
  *
@@ -343,7 +343,7 @@ static int phg_data_extension (int power, int height, int gain, char *dir, char 
  *
  * Purpose:     Fill in parts of the course & speed data extension.
  *
- * Inputs: 	course	- Degress, 0 - 360 (360 equiv. to 0).
+ * Inputs: 	course	- Degrees, 0 - 360 (360 equiv. to 0).
  *			  Use G_UNKNOWN for none or unknown.
  *
  *		speed	- knots.
@@ -494,7 +494,7 @@ static int frequency_spec (float freq, float tone, float offset, char *presult)
  *		gain	- dB.  Not clear if it is dBi or dBd.
  *		dir	- Directivity: N, NE, etc., omni.
  *
- *		course	- Degress, 0 - 360 (360 equiv. to 0).
+ *		course	- Degrees, 0 - 360 (360 equiv. to 0).
  *			  Use G_UNKNOWN for none or unknown.
  *		speed	- knots.		// TODO:  should distinguish unknown(not revevant) vs. known zero.
  *
@@ -636,7 +636,7 @@ int encode_position (int messaging, int compressed, double lat, double lon, int 
  *		gain	- dB.  Not clear if it is dBi or dBd.
  *		dir	- Direction: N, NE, etc., omni.
  *
- *		course	- Degress, 0 - 360 (360 equiv. to 0).
+ *		course	- Degrees, 0 - 360 (360 equiv. to 0).
  *			  Use G_UNKNOWN for none or unknown.
  *		speed	- knots.
  *

--- a/src/il2p_codec.c
+++ b/src/il2p_codec.c
@@ -83,7 +83,7 @@ int il2p_encode_frame (packet_t pp, int max_fec, unsigned char *iout)
 	    out_len = IL2P_HEADER_SIZE + IL2P_HEADER_PARITY;
 
 	    if (e == 0) {
-	        // Sucess. No info part.
+	        // Success. No info part.
 	        return (out_len);
 	    }
 

--- a/src/il2p_codec.c-bak16
+++ b/src/il2p_codec.c-bak16
@@ -85,7 +85,7 @@ int il2p_encode_frame (packet_t pp, int max_fec, unsigned char *iout)
 	    out_len = IL2P_HEADER_SIZE + IL2P_HEADER_PARITY;
 
 	    if (e == 0) {
-	        // Sucess. No info part.
+	        // Success. No info part.
 	        return (out_len);
 	    }
 

--- a/src/il2p_header.c
+++ b/src/il2p_header.c
@@ -122,7 +122,7 @@ static int get_field (unsigned char *hdr, int bit_num, int lsb_index, int width)
 
 
 // AX.25 'I' and 'UI' frames have a protocol ID which determines how the
-// information part should be interpretted.
+// information part should be interpreted.
 // Here we squeeze the most common cases down to 4 bits.
 // Return -1 if translation is not possible.  Fall back to type 0 header in this case.
 
@@ -299,7 +299,7 @@ int il2p_type_1_header (packet_t pp, int max_fec, unsigned char *hdr)
 
 	        if (frame_type == frame_type_U_UI) {
 	            SET_UI(hdr, 1);	// I guess this is how we distinguish 'I' and 'UI'
-					// on the receving end.
+					// on the receiving end.
 	            int pid = encode_pid(pp);
 	            if (pid < 0) return (-1);
 	            SET_PID(hdr, pid);
@@ -320,7 +320,7 @@ int il2p_type_1_header (packet_t pp, int max_fec, unsigned char *hdr)
 		//	1	1	1	Not valid (earlier protocol version)
 		//
 		// APRS does not mention how to set these bits and all 4 combinations
-		// are seen in the wild.  Apparently these are ignord on receive and no
+		// are seen in the wild.  Apparently these are ignored on receive and no
 		// one cares.  Here we copy from the C bit in the destination address.
 		// It should be noted that the case of both C bits being the same can't
 		// be represented so the il2p encode/decode bit not produce exactly the

--- a/src/il2p_init.c
+++ b/src/il2p_init.c
@@ -157,7 +157,7 @@ void il2p_encode_rs (unsigned char *tx_data, int data_size, int num_parity, unsi
  *				data_size bytes.
  *
  * Returns:	-1 for unrecoverable.
- *		>= 0 for sucess.  Number of symbols corrected.
+ *		>= 0 for success.  Number of symbols corrected.
  *
  *--------------------------------------------------------------*/
 

--- a/src/il2p_payload.c
+++ b/src/il2p_payload.c
@@ -125,7 +125,7 @@ int il2p_payload_compute (il2p_payload_properties_t *p, int payload_size, int ma
  *		0 for no blocks.  (i.e. size zero)
  *		Number of bytes generated.  Maximum IL2P_MAX_ENCODED_SIZE.
  *
- * Note:	I interpretted the protocol spec as saying the LFSR state is retained
+ * Note:	I interpreted the protocol spec as saying the LFSR state is retained
  *		between data blocks.  During interoperability testing, I found that
  *		was not the case.  It is reset for each data block.
  *

--- a/src/il2p_payload.c-bak16
+++ b/src/il2p_payload.c-bak16
@@ -125,7 +125,7 @@ int il2p_payload_compute (il2p_payload_properties_t *p, int payload_size, int ma
  *		0 for no blocks.  (i.e. size zero)
  *		Number of bytes generated.  Maximum IL2P_MAX_ENCODED_SIZE.
  *
- * Note:	I interpretted the protocol spec as saying the LFSR state is retained
+ * Note:	I interpreted the protocol spec as saying the LFSR state is retained
  *		between data blocks.  During interoperability testing, I found that
  *		was not the case.  It is reset for each data block.
  *

--- a/src/il2p_scramble.c-bak16
+++ b/src/il2p_scramble.c-bak16
@@ -74,7 +74,7 @@ static inline int descramble_bit (int in, int *state)
  *
  * Outputs:	lfsr_state	Current state of transmit LFSR.
  *				This is reset at the start of the packet and is
- *				cummulative across the header and data blocks.
+ *				cumulative across the header and data blocks.
  *
  *--------------------------------------------------------------------------------*/
 
@@ -151,7 +151,7 @@ void il2p_scramble_block (unsigned char *in, unsigned char *out, int len, int *l
  * Purpose:	Reset the RX LFSR register at the beginning of a packet or payload.
  *
  * Outputs:	lfsr_state	Current state of transmit LFSR.
- *				This is cummulative across the payload data blocks.
+ *				This is cumulative across the payload data blocks.
  *
  *--------------------------------------------------------------------------------*/
 

--- a/src/il2p_test.c
+++ b/src/il2p_test.c
@@ -957,7 +957,7 @@ void multi_modem_process_rec_packet (int chan, int subchan, int slice, packet_t 
 	assert (strcmp(text, (char*)pinfo) == 0);
 
 	dw_printf ("Number of symbols corrected: %d\n", retries);
-	if (polarity == 2) {	// expecting errors corrrected.
+	if (polarity == 2) {	// expecting errors corrected.
 	    assert (retries == 10);
 	}
 	else {	// should be no errors.

--- a/src/il2p_test.c-bak16
+++ b/src/il2p_test.c-bak16
@@ -1010,7 +1010,7 @@ void multi_modem_process_rec_packet (int chan, int subchan, int slice, packet_t 
 	assert (strcmp(text, (char*)pinfo) == 0);
 
 	dw_printf ("Number of symbols corrected: %d\n", retries);
-	if (polarity == 2) {	// expecting errors corrrected.
+	if (polarity == 2) {	// expecting errors corrected.
 	    assert (retries == 10);
 	}
 	else {	// should be no errors.

--- a/src/kiss_frame.h
+++ b/src/kiss_frame.h
@@ -66,7 +66,7 @@ typedef struct kiss_frame_s {
 
 
 // This is used only for TCPKISS but it put in kissnet.h,
-// there would be a circular dependecy between the two header files.
+// there would be a circular dependency between the two header files.
 // Each KISS TCP port has its own status block.
 
 struct kissport_status_s {

--- a/src/mheard.c
+++ b/src/mheard.c
@@ -102,7 +102,7 @@ typedef struct mheard_s {
 
 	double dlat, dlon;			// Last position.  G_UNKNOWN for unknown.
 
-	int msp;				// Allow message sender positon report.
+	int msp;				// Allow message sender position report.
 						// When non zero, an IS>RF position report is allowed.
 						// Then decremented.
 
@@ -768,7 +768,7 @@ void mheard_set_msp (char *callsign, int num)
  *
  * Inputs:	callsign	- Callsign for station which sent the "message."
  *
- * Returns:	The cound for the specified station.
+ * Returns:	The count for the specified station.
  *		0 if not found.
  *
  *------------------------------------------------------------------*/

--- a/src/tnctest.c
+++ b/src/tnctest.c
@@ -615,7 +615,7 @@ void process_rec_data (int my_index, char *data)
  *				  and sent to a common function to check that they
  *				  all arrived in order.
  *
- * Global Out:	is_connected	- Updated when connected/disconnected notfications are received.
+ * Global Out:	is_connected	- Updated when connected/disconnected notifications are received.
  *
  * Description:	Perform any necessary configuration for the TNC then wait
  *		for responses and process them.
@@ -943,7 +943,7 @@ static void * tnc_thread_net (void *arg)
  *				  and sent to a common function to check that they
  *				  all arrived in order.
  *
- * Global Out:	is_connected	- Updated when connected/disconnected notfications are received.
+ * Global Out:	is_connected	- Updated when connected/disconnected notifications are received.
  *
  * Description:	Perform any necessary configuration for the TNC then wait
  *		for responses and process them.
@@ -1257,7 +1257,7 @@ static void tnc_send_data (int from, int to, char * data)
 	else {
 
 	  // The assumption is that we are in CONVERS mode.
-	  // The data sould be terminated by carriage return.
+	  // The data should be terminated by carriage return.
 
 	  int timeout = 600;	// 60 sec.  I've seen it take more than 20.
 	  while (timeout > 0 && busy[from]) {


### PR DESCRIPTION
Somehow I messed these errors during a previous run of codespell.

Found with codespell with manual input:
codespell -w -i 2 --ignore-words-list=dout,inout,ist,ot,parm,usng --skip=*.txt,src/mgn_icon.h,src/grm_sym.h src/