### PR TITLE
decode_aprs.c: Limit __compar_fn_t to Linux

### DIFF
--- a/src/decode_aprs.c
+++ b/src/decode_aprs.c
@@ -3935,10 +3935,11 @@ static void decode_tocall (decode_aprs_t *A, char *dest)
  * models before getting to the more generic APY.
  */
 
-#if defined(__WIN32__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__APPLE__)
-	    qsort (tocalls, num_tocalls, sizeof(struct tocalls_s), tocall_cmp);
-#else
+#if defined(__linux__)
+	    /* glibc defines __compar_fn_t, which is not defined by POSIX. */
 	    qsort (tocalls, num_tocalls, sizeof(struct tocalls_s), (__compar_fn_t)tocall_cmp);
+#else
+	    qsort (tocalls, num_tocalls, sizeof(struct tocalls_s), tocall_cmp);
 #endif
 	  }
 	  else {


### PR DESCRIPTION
POSIX does not define __compar_fn_t.   Rather than using it, except on
a list of systems where it does not exist, invert the conditional so that
it is used when it is known to exist, and on other systems --
including unknown systems -- use a POSIX-compatible invocation.

Probably switching on __linux__ isn't really right, and instead there
should be a feature test in cmake.  Alternatively, since passing
tocall_cmp without a cast doesn't result in warning, because it is the
same type except static, it would be simpler to just drop the use of
__compar_fn_t entirely.