### PR TITLE
Restore terminal background colour on quit

### DIFF
--- a/src/aclients.c
+++ b/src/aclients.c
@@ -221,6 +221,7 @@ int main (int argc, char *argv[])
 
 	if (num_clients < 1 || num_clients > MAX_CLIENTS) {
 	  printf ("Specify up to %d TNCs on the command line.\n", MAX_CLIENTS);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -236,6 +237,7 @@ int main (int argc, char *argv[])
 	  p = strtok (stemp, "=");
 	  if (p == NULL) {
 	    printf ("Internal error 1\n");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 	  strlcpy (hostname[j], "localhost", sizeof(hostname[j]));
@@ -243,6 +245,7 @@ int main (int argc, char *argv[])
 	  p = strtok (NULL, "=");
 	  if (p == NULL) {
 	    printf ("Missing description after %s\n", port[j]);
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 	  strlcpy (description[j], p, sizeof(description[j]));
@@ -291,6 +294,7 @@ int main (int argc, char *argv[])
 	  }
 	  if (client_th[j] == NULL) {
 	    printf ("Internal error: Could not create client thread %d.\n", j);
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 #else
@@ -302,6 +306,7 @@ int main (int argc, char *argv[])
 	  }
 	  if (e != 0) {
 	    perror("Internal error: Could not create client thread.");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 #endif
@@ -438,6 +443,7 @@ static void * client_thread_net (void *arg)
 					hostname[my_index], gai_strerror(err));
 #endif
 	  freeaddrinfo(ai_head);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
       	  exit (1);
 	}
 
@@ -536,6 +542,7 @@ static void * client_thread_net (void *arg)
 
  	  printf("Client %d unable to connect to %s on %s (%s), port %s\n", 
 			my_index, description[my_index], hostname[my_index], ipaddr_str, port[my_index] );
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -563,6 +570,7 @@ static void * client_thread_net (void *arg)
 
 	  if (n != sizeof(mon_cmd)) {
 	    printf ("Read error, client %d received %d command bytes.  Terminating.\n", my_index, n);
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 
@@ -577,6 +585,7 @@ static void * client_thread_net (void *arg)
 
 	    if (n != mon_cmd.data_len) {
 	      printf ("Read error, client %d received %d data bytes.\n", my_index, n);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    }
 	  }
@@ -682,6 +691,7 @@ static void * client_thread_serial (void *arg)
 	if (fd == MYFDERROR) {
  	  printf("Client %d unable to connect to %s on %s.\n", 
 			my_index, description[my_index], port[my_index] );
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -732,6 +742,7 @@ static void * client_thread_serial (void *arg)
 	if (fd == MYFDERROR) {
  	  printf("Client %d unable to connect to %s on %s.\n", 
 			my_index, description[my_index], port[my_index] );
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -781,6 +792,7 @@ static void * client_thread_serial (void *arg)
 	    if (! ReadFile (fd, &ch, 1, &n, NULL)) {
 	      printf ("Read error on %s.\n", description[my_index]);
 	      CloseHandle (fd);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    }
 	  
@@ -790,6 +802,7 @@ static void * client_thread_serial (void *arg)
 	    if ( ( n = read(fd, & ch, 1)) < 0) {
 	      printf ("Read error on %s.\n", description[my_index]);
 	      close (fd);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    }
 #endif

--- a/src/appserver.c
+++ b/src/appserver.c
@@ -56,6 +56,7 @@ static void usage()
 	      dw_printf ("        mycall    is required because that is the callsign for  \n");
 	      dw_printf ("                  which the TNC will accept connections. \n");
 	      dw_printf (" \n");
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 }
 
@@ -192,6 +193,7 @@ int main (int argc, char *argv[])
 	if (agwlib_init (tnc_hostname, tnc_port, agwlib_G_ask_port_information) != 0) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Could not attach to network TNC %s:%s.\n", tnc_hostname, tnc_port);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 

--- a/src/atest.c
+++ b/src/atest.c
@@ -604,21 +604,21 @@ int main (int argc, char *argv[])
 	if (format.wformattag != 1) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Sorry, I only understand audio format 1 (PCM).  This file has %d.\n", format.wformattag);
-          dw_printf ("\e[0m\e\n\e[0J\e");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
 	if (format.nchannels != 1 && format.nchannels != 2) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Sorry, I only understand 1 or 2 channels.  This file has %d.\n", format.nchannels);
-          dw_printf ("\e[0m\e\n\e[0J\e");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
 	if (format.wbitspersample != 8 && format.wbitspersample != 16) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Sorry, I only understand 8 or 16 bits per sample.  This file has %d.\n", format.wbitspersample);
-          dw_printf ("\e[0m\e\n\e[0J\e");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
@@ -721,17 +721,17 @@ int main (int argc, char *argv[])
 	if (error_if_less_than != -1 && packets_decoded_total < error_if_less_than) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("\n * * * TEST FAILED: number decoded is less than %d * * * \n", error_if_less_than);
-          dw_printf ("\e[0m\e\n\e[0J\e");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 	if (error_if_greater_than != -1 && packets_decoded_total > error_if_greater_than) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("\n * * * TEST FAILED: number decoded is greater than %d * * * \n", error_if_greater_than);
-          dw_printf ("\e[0m\e\n\e[0J\e");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
-        dw_printf ("\e[0m\e\n\e[0J\e");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 }
 
@@ -1023,7 +1023,7 @@ static void usage (void) {
 	dw_printf ("              Try  different combinations of options to compare decoding\n");
 	dw_printf ("              performance.\n");
 
-        dw_printf ("\e[0m\e\n\e[0J\e");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (1);
 }
 

--- a/src/atest.c
+++ b/src/atest.c
@@ -314,6 +314,7 @@ int main (int argc, char *argv[])
 	      if (decimate < 1 || decimate > 8) {
 		text_color_set(DW_COLOR_ERROR);
 		dw_printf ("Unreasonable value for -D.\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
 		exit (EXIT_FAILURE);
 	      }
 	      dw_printf ("Divide audio sample rate by %d\n", decimate);
@@ -331,6 +332,7 @@ int main (int argc, char *argv[])
 	      if (upsample < 1 || upsample > 4) {
 		text_color_set(DW_COLOR_ERROR);
 		dw_printf ("Unreasonable value for -U.\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
 		exit (EXIT_FAILURE);
 	      }
 	      dw_printf ("Multiply audio sample rate by %d\n", upsample);
@@ -344,6 +346,7 @@ int main (int argc, char *argv[])
 	      if (my_audio_config.achan[0].fix_bits < RETRY_NONE || my_audio_config.achan[0].fix_bits >= RETRY_MAX) {
 		text_color_set(DW_COLOR_ERROR);
 		dw_printf ("Invalid Fix Bits level.\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
 		exit (EXIT_FAILURE);
 	      }
 	      break;	
@@ -424,6 +427,7 @@ int main (int argc, char *argv[])
         if (my_audio_config.achan[0].baud < MIN_BAUD || my_audio_config.achan[0].baud > MAX_BAUD) {
 	  text_color_set(DW_COLOR_ERROR);
           dw_printf ("Use a more reasonable bit rate in range of %d - %d.\n", MIN_BAUD, MAX_BAUD);
+          dw_printf ("\e[0m\e\n\e[0J\e");
           exit (EXIT_FAILURE);
         }
 
@@ -547,6 +551,7 @@ int main (int argc, char *argv[])
 	  text_color_set(DW_COLOR_ERROR);
           dw_printf ("Couldn't open file for read: %s\n", argv[optind]);
 	  //perror ("more info?");
+          dw_printf ("\e[0m\e\n\e[0J\e");
           exit (EXIT_FAILURE);
         }
 
@@ -561,6 +566,7 @@ int main (int argc, char *argv[])
 	if (strncmp(header.riff, "RIFF", 4) != 0 || strncmp(header.wave, "WAVE", 4) != 0) {
 	  text_color_set(DW_COLOR_ERROR);
           dw_printf ("This is not a .WAV format file.\n");
+          dw_printf ("\e[0m\e\n\e[0J\e");
           exit (EXIT_FAILURE);
 	}
 
@@ -574,11 +580,13 @@ int main (int argc, char *argv[])
 	if (strncmp(chunk.id, "fmt ", 4) != 0) {
 	  text_color_set(DW_COLOR_ERROR);
           dw_printf ("WAV file error: Found \"%4.4s\" where \"fmt \" was expected.\n", chunk.id);
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit(EXIT_FAILURE);
 	}
 	if (chunk.datasize != 16 && chunk.datasize != 18) {
 	  text_color_set(DW_COLOR_ERROR);
           dw_printf ("WAV file error: Need fmt chunk datasize of 16 or 18.  Found %d.\n", chunk.datasize);
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit(EXIT_FAILURE);
 	}
 
@@ -589,24 +597,28 @@ int main (int argc, char *argv[])
 	if (strncmp(wav_data.data, "data", 4) != 0) {
 	  text_color_set(DW_COLOR_ERROR);
           dw_printf ("WAV file error: Found \"%4.4s\" where \"data\" was expected.\n", wav_data.data);
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit(EXIT_FAILURE);
 	}
 
 	if (format.wformattag != 1) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Sorry, I only understand audio format 1 (PCM).  This file has %d.\n", format.wformattag);
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
 	if (format.nchannels != 1 && format.nchannels != 2) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Sorry, I only understand 1 or 2 channels.  This file has %d.\n", format.nchannels);
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
 	if (format.wbitspersample != 8 && format.wbitspersample != 16) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Sorry, I only understand 8 or 16 bits per sample.  This file has %d.\n", format.wbitspersample);
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
@@ -709,14 +721,17 @@ int main (int argc, char *argv[])
 	if (error_if_less_than != -1 && packets_decoded_total < error_if_less_than) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("\n * * * TEST FAILED: number decoded is less than %d * * * \n", error_if_less_than);
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 	if (error_if_greater_than != -1 && packets_decoded_total > error_if_greater_than) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("\n * * * TEST FAILED: number decoded is greater than %d * * * \n", error_if_greater_than);
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
+        dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 }
 
@@ -1008,6 +1023,7 @@ static void usage (void) {
 	dw_printf ("              Try  different combinations of options to compare decoding\n");
 	dw_printf ("              performance.\n");
 
+        dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (1);
 }
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -1056,7 +1056,7 @@ int audio_get (int a)
 	      if (res <= 0) {
 	        text_color_set(DW_COLOR_INFO);
 	        dw_printf ("\nEnd of file on stdin.  Exiting.\n");
-                dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
 	        exit (0);
 	      }
 	    

--- a/src/audio.c
+++ b/src/audio.c
@@ -1056,6 +1056,7 @@ int audio_get (int a)
 	      if (res <= 0) {
 	        text_color_set(DW_COLOR_INFO);
 	        dw_printf ("\nEnd of file on stdin.  Exiting.\n");
+                dw_printf ("\e[0m\e\n\e[0J\e");
 	        exit (0);
 	      }
 	    

--- a/src/audio_portaudio.c
+++ b/src/audio_portaudio.c
@@ -1084,6 +1084,7 @@ int audio_get (int a)
 				if (res <= 0) {
 					text_color_set(DW_COLOR_INFO);
 					dw_printf ("\nEnd of file on stdin.  Exiting.\n");
+					dw_printf ("\e[0m\e\n\e[0J\e");
 					exit (0);
 				}
 

--- a/src/audio_win.c
+++ b/src/audio_win.c
@@ -890,6 +890,7 @@ int audio_get (int a)
 	      if (res <= 0) {
 	        text_color_set(DW_COLOR_INFO);
 	        dw_printf ("\nEnd of file on stdin.  Exiting.\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
 	        exit (0);
 	      }
 

--- a/src/audio_win.c
+++ b/src/audio_win.c
@@ -890,7 +890,7 @@ int audio_get (int a)
 	      if (res <= 0) {
 	        text_color_set(DW_COLOR_INFO);
 	        dw_printf ("\nEnd of file on stdin.  Exiting.\n");
-		dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
 	        exit (0);
 	      }
 

--- a/src/ax25_pad2.c
+++ b/src/ax25_pad2.c
@@ -929,6 +929,7 @@ int main ()
 	dw_printf ("\n----------\n\n");
 	dw_printf ("\nSUCCESS!\n");
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 
 } /* end main */

--- a/src/cm108.c
+++ b/src/cm108.c
@@ -685,6 +685,7 @@ int main (int argc, char *argv[])
 	if (argc != 2) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Specify HID path on command line.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 

--- a/src/config.c
+++ b/src/config.c
@@ -1833,6 +1833,7 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 #if __WIN32__
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("Config file line %d: Windows version of direwolf does not support HAMLIB.\n", line);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 #else
 	      text_color_set(DW_COLOR_ERROR);
@@ -1919,6 +1920,7 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 	      dw_printf ("You must rebuild direwolf with CM108 Audio Adapter GPIO PTT support.\n");
 	      dw_printf ("See User Guide for details.\n");
 #endif
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 #endif
 	    }
@@ -4219,6 +4221,7 @@ void config_init (char *fname, struct audio_s *p_audio_config,
    	      }
 	    }
 	    //dw_printf ("DEBUG  server=%s   port=%d\n", p_igate_config->t2_server_name, p_igate_config->t2_server_port);
+	    //dw_printf ("\e[0m\e\n\e[0J\e");
 	    //exit (0);
 	  }
 

--- a/src/decode_aprs.c
+++ b/src/decode_aprs.c
@@ -4805,6 +4805,7 @@ int main (int argc, char *argv[])
 	if (argc >= 2) {
 	  if (freopen (argv[1], "r", stdin) == NULL) {
 	    fprintf(stderr, "Can't open %s for read.\n", argv[1]);
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit(1);
 	  }
 	}

--- a/src/demod.c
+++ b/src/demod.c
@@ -993,6 +993,7 @@ void demod_process_sample (int chan, int subchan, int sam)
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("Invalid combination of options.  Exiting.\n");
 	      // Would probably work but haven't thought about it or tested yet.
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    }
 	    else {

--- a/src/demod_afsk.c
+++ b/src/demod_afsk.c
@@ -267,6 +267,7 @@ void demod_afsk_init (int samples_per_sec, int baud, int mark_freq,
 
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("Invalid filter profile = %c\n", profile);
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	}
 
@@ -352,6 +353,7 @@ void demod_afsk_init (int samples_per_sec, int baud, int mark_freq,
 	  dw_printf ("Decrease the audio sample rate or increase the baud rate or\n");
 	  dw_printf ("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 							MAX_FILTER_SIZE);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -362,6 +364,7 @@ void demod_afsk_init (int samples_per_sec, int baud, int mark_freq,
 	  dw_printf ("Decrease the audio sample rate or increase the baud rate or\n");
 	  dw_printf ("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 							MAX_FILTER_SIZE);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -374,6 +377,7 @@ void demod_afsk_init (int samples_per_sec, int baud, int mark_freq,
 	  dw_printf ("Decrease the audio sample rate or increase the baud rate or\n");
 	  dw_printf ("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 							MAX_FILTER_SIZE);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 

--- a/src/demod_psk.c
+++ b/src/demod_psk.c
@@ -446,6 +446,7 @@ void demod_psk_init (enum modem_t modem_type, enum v26_e v26_alt, int samples_pe
 	  dw_printf ("Decrease the audio sample rate or increase the baud rate or\n");
 	  dw_printf ("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 							MAX_FILTER_SIZE);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -455,6 +456,7 @@ void demod_psk_init (enum modem_t modem_type, enum v26_e v26_alt, int samples_pe
 	  dw_printf ("Decrease the audio sample rate or increase the baud rate or\n");
 	  dw_printf ("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 							MAX_FILTER_SIZE);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -464,6 +466,7 @@ void demod_psk_init (enum modem_t modem_type, enum v26_e v26_alt, int samples_pe
 	  dw_printf ("Decrease the audio sample rate or increase the baud rate or\n");
 	  dw_printf ("recompile the application with MAX_FILTER_SIZE larger than %d.\n",
 							MAX_FILTER_SIZE);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 

--- a/src/digipeater.c
+++ b/src/digipeater.c
@@ -737,6 +737,7 @@ int main (int argc, char *argv[])
 	  regerror (e, &alias_re, message, sizeof(message));
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("\n%s\n\n", message);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -745,6 +746,7 @@ int main (int argc, char *argv[])
 	  regerror (e, &wide_re, message, sizeof(message));
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("\n%s\n\n", message);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 

--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -444,6 +444,7 @@ int main (int argc, char *argv[])
             if (B_opt < MIN_BAUD || B_opt > MAX_BAUD) {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf ("Use a more reasonable data baud rate in range of %d - %d.\n", MIN_BAUD, MAX_BAUD);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
               exit (EXIT_FAILURE);
             }
             break;
@@ -475,6 +476,7 @@ int main (int argc, char *argv[])
             if (D_opt < 1 || D_opt > 8) {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf ("Crazy value for -D. \n");
+	      dw_printf ("\e[0m\e\n\e[0J\e");
               exit (EXIT_FAILURE);
             }
             break;
@@ -485,6 +487,7 @@ int main (int argc, char *argv[])
             if (U_opt < 1 || U_opt > 4) {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf ("Crazy value for -U. \n");
+	      dw_printf ("\e[0m\e\n\e[0J\e");
               exit (EXIT_FAILURE);
             }
             break;
@@ -597,6 +600,7 @@ int main (int argc, char *argv[])
 			0xc2, 0xb0,
 			0xc3, 0xbc, 0xc3, 0x9f);
 
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (0);
 	    break;
 
@@ -615,6 +619,7 @@ int main (int argc, char *argv[])
 
 	    symbols_init ();
 	    symbols_list ();
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (0);
 	    break;
 
@@ -831,6 +836,7 @@ int main (int argc, char *argv[])
 	if (strlen(l_opt_logdir) > 0 && strlen(L_opt_logfile) > 0) {
           text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Logging options -l and -L can't be used together.  Pick one or the other.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit(1);
 	}
 
@@ -870,6 +876,7 @@ int main (int argc, char *argv[])
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Pointless to continue without audio device.\n");
 	  SLEEP_SEC(5);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -926,6 +933,7 @@ int main (int argc, char *argv[])
 
 	  }
 	  ptt_set (OCTYPE_PTT, chan, 0);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (0);
 	}
 
@@ -977,6 +985,7 @@ int main (int argc, char *argv[])
 	recv_init (&audio_config);
 	recv_process ();
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 }
 
@@ -1412,7 +1421,7 @@ static BOOL cleanup_win (int ctrltype)
 {
 	if (ctrltype == CTRL_C_EVENT || ctrltype == CTRL_CLOSE_EVENT) {
 	  text_color_set(DW_COLOR_INFO);
-	  dw_printf ("\nQRT\n");
+	  dw_printf ("\nQRT\e[0m\e\n\e[0J\e");
 	  log_term ();
 	  ptt_term ();
 	  waypoint_term ();
@@ -1429,11 +1438,12 @@ static BOOL cleanup_win (int ctrltype)
 static void cleanup_linux (int x)
 {
 	text_color_set(DW_COLOR_INFO);
-	dw_printf ("\nQRT\n");
+	dw_printf ("\nQRT\e[0m\e\n\e[0J\e");
 	log_term ();
 	ptt_term ();
 	dwgps_term ();
 	SLEEP_SEC(1);
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit(0);
 }
 
@@ -1511,11 +1521,14 @@ static void usage (char **argv)
   
 #if __WIN32__
 	dw_printf ("Complete documentation can be found in the 'doc' folder\n");
+	/* I don't know if win32 supports ANSI colour sequences. */
 #else
 	// TODO: Could vary by platform and build options.
-	dw_printf ("Complete documentation can be found in /usr/local/share/doc/direwolf\n");
+	//dw_printf ("Complete documentation can be found in /usr/local/share/doc/direwolf\n");
+	//dw_printf ("\e[0m\e\n\e[0J\e");	/* This appears to break the last bit of colour, so it is commented out. */
 #endif
 	dw_printf ("or online at https://github.com/wb2osz/direwolf/tree/master/doc\n");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_FAILURE);
 }
 

--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -1520,7 +1520,7 @@ static void usage (char **argv)
   
 #if __WIN32__
 	dw_printf ("Complete documentation can be found in the 'doc' folder\n");
-	/* I don't know if win32 supports ANSI colour sequences. */
+	// I don't know if win32 supports ANSI colour sequences.
 	dw_printf ("\e[0m\e\n\e[0J\e");
 #else
 	// TODO: Could vary by platform and build options.

--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -1524,7 +1524,7 @@ static void usage (char **argv)
 	/* I don't know if win32 supports ANSI colour sequences. */
 #else
 	// TODO: Could vary by platform and build options.
-	//dw_printf ("Complete documentation can be found in /usr/local/share/doc/direwolf\n");
+	dw_printf ("Complete documentation can be found in /usr/local/share/doc/direwolf\n");
 	//dw_printf ("\e[0m\e\n\e[0J\e");	/* This appears to break the last bit of colour, so it is commented out. */
 #endif
 	dw_printf ("or online at https://github.com/wb2osz/direwolf/tree/master/doc\n");
@@ -1535,3 +1535,4 @@ static void usage (char **argv)
 
 
 /* end direwolf.c */
+

--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -444,7 +444,7 @@ int main (int argc, char *argv[])
             if (B_opt < MIN_BAUD || B_opt > MAX_BAUD) {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf ("Use a more reasonable data baud rate in range of %d - %d.\n", MIN_BAUD, MAX_BAUD);
-	      dw_printf ("\e[0m\e\n\e[0J\e");
+              dw_printf ("\e[0m\e\n\e[0J\e");
               exit (EXIT_FAILURE);
             }
             break;
@@ -476,7 +476,7 @@ int main (int argc, char *argv[])
             if (D_opt < 1 || D_opt > 8) {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf ("Crazy value for -D. \n");
-	      dw_printf ("\e[0m\e\n\e[0J\e");
+              dw_printf ("\e[0m\e\n\e[0J\e");
               exit (EXIT_FAILURE);
             }
             break;
@@ -487,7 +487,7 @@ int main (int argc, char *argv[])
             if (U_opt < 1 || U_opt > 4) {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf ("Crazy value for -U. \n");
-	      dw_printf ("\e[0m\e\n\e[0J\e");
+              dw_printf ("\e[0m\e\n\e[0J\e");
               exit (EXIT_FAILURE);
             }
             break;
@@ -1443,7 +1443,6 @@ static void cleanup_linux (int x)
 	ptt_term ();
 	dwgps_term ();
 	SLEEP_SEC(1);
-	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit(0);
 }
 
@@ -1522,10 +1521,10 @@ static void usage (char **argv)
 #if __WIN32__
 	dw_printf ("Complete documentation can be found in the 'doc' folder\n");
 	/* I don't know if win32 supports ANSI colour sequences. */
+	dw_printf ("\e[0m\e\n\e[0J\e");
 #else
 	// TODO: Could vary by platform and build options.
 	dw_printf ("Complete documentation can be found in /usr/local/share/doc/direwolf\n");
-	//dw_printf ("\e[0m\e\n\e[0J\e");	/* This appears to break the last bit of colour, so it is commented out. */
 #endif
 	dw_printf ("or online at https://github.com/wb2osz/direwolf/tree/master/doc\n");
 	dw_printf ("\e[0m\e\n\e[0J\e");

--- a/src/direwolf.h
+++ b/src/direwolf.h
@@ -9,6 +9,7 @@
 #endif
 
 
+
 #ifndef DIREWOLF_H
 #define DIREWOLF_H 1
 
@@ -315,6 +316,5 @@ size_t strlcat_debug(char *__restrict__ dst, const char *__restrict__ src, size_
 #endif  /* DEBUG_STRL */
 
 #endif	/* BSD or Apple */
-
 
 #endif   /* ifndef DIREWOLF_H */

--- a/src/direwolf.h
+++ b/src/direwolf.h
@@ -9,7 +9,6 @@
 #endif
 
 
-
 #ifndef DIREWOLF_H
 #define DIREWOLF_H 1
 
@@ -316,5 +315,6 @@ size_t strlcat_debug(char *__restrict__ dst, const char *__restrict__ src, size_
 #endif  /* DEBUG_STRL */
 
 #endif	/* BSD or Apple */
+
 
 #endif   /* ifndef DIREWOLF_H */

--- a/src/dlq.c
+++ b/src/dlq.c
@@ -135,6 +135,7 @@ void dlq_init (void)
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("dlq_init: pthread_mutex_init err=%d", err);
 	  perror ("");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 #endif
@@ -153,6 +154,7 @@ void dlq_init (void)
 	if (wake_up_event == NULL) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("dlq_init: pthread_cond_init: can't create receive wake up event");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -170,6 +172,7 @@ void dlq_init (void)
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("dlq_init: pthread_cond_init err=%d", err);
 	  perror ("");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -325,6 +328,7 @@ static void append_to_queue (struct dlq_item_s *pnew)
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("dlq append_to_queue: pthread_mutex_lock err=%d", err);
 	  perror ("");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 #endif
@@ -352,6 +356,7 @@ static void append_to_queue (struct dlq_item_s *pnew)
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("dlq append_to_queue: pthread_mutex_unlock err=%d", err);
 	  perror ("");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 #endif
@@ -425,6 +430,7 @@ static void append_to_queue (struct dlq_item_s *pnew)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("dlq append_to_queue: pthread_mutex_lock wu err=%d", err);
 	    perror ("");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 
@@ -433,6 +439,7 @@ static void append_to_queue (struct dlq_item_s *pnew)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("dlq append_to_queue: pthread_cond_signal err=%d", err);
 	    perror ("");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 
@@ -441,6 +448,7 @@ static void append_to_queue (struct dlq_item_s *pnew)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("dlq append_to_queue: pthread_mutex_unlock wu err=%d", err);
 	    perror ("");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 	}
@@ -991,6 +999,7 @@ int dlq_wait_while_empty (double timeout)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("dlq_wait_while_empty: pthread_mutex_lock wu err=%d", err);
 	    perror ("");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 
@@ -1016,6 +1025,7 @@ int dlq_wait_while_empty (double timeout)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("dlq_wait_while_empty: pthread_mutex_unlock wu err=%d", err);
 	    perror ("");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 #endif
@@ -1071,6 +1081,7 @@ struct dlq_item_s *dlq_remove (void)
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("dlq_remove: pthread_mutex_lock err=%d", err);
 	  perror ("");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 #endif
@@ -1088,6 +1099,7 @@ struct dlq_item_s *dlq_remove (void)
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("dlq_remove: pthread_mutex_unlock err=%d", err);
 	  perror ("");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 #endif

--- a/src/dtmf.c
+++ b/src/dtmf.c
@@ -448,12 +448,14 @@ static void push_button (int chan, char button, int ms)
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("\n * Time-out failed, otherwise OK *\n");
 	      dw_printf ("\"%s\"\n", result);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 	    }
 	    else {
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("\n *** TEST FAILED ***\n");
 	      dw_printf ("\"%s\"\n", result);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 	    }
 	    break;
@@ -584,6 +586,7 @@ int main ()
 
 	push_button (c,  '?', 0);
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 
 }  /* end main */

--- a/src/dwgpsd.c
+++ b/src/dwgpsd.c
@@ -507,6 +507,7 @@ int main (int argc, char *argv[])
 	      break;
 	    case DWFIX_NOT_INIT:
 	      dw_printf ("GPS Init failed.\n");
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    case DWFIX_ERROR:
 	    default:

--- a/src/dwgpsnmea.c
+++ b/src/dwgpsnmea.c
@@ -815,6 +815,7 @@ int main (int argc, char *argv[])
 	      break;
 	    case DWFIX_NOT_INIT:
 	      dw_printf ("GPS Init failed.\n");
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    case DWFIX_ERROR:
 	    default:

--- a/src/encode_aprs.c
+++ b/src/encode_aprs.c
@@ -935,6 +935,7 @@ int main (int argc, char *argv[])
 	if (errors > 0) {
 	  text_color_set (DW_COLOR_ERROR);
 	  dw_printf ("Encode APRS test FAILED with %d errors.\n", errors);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
@@ -960,11 +961,13 @@ int main (int argc, char *argv[])
 	if (errors != 0) {
 	  text_color_set (DW_COLOR_ERROR);
 	  dw_printf ("Encode APRS test FAILED with %d errors.\n", errors);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
 	text_color_set (DW_COLOR_REC);
 	dw_printf ("Encode APRS test PASSED with no errors.\n");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 	
 

--- a/src/fx25_init.c
+++ b/src/fx25_init.c
@@ -194,6 +194,7 @@ void fx25_init ( int debug_level )
 	  if (Tab[i].rs == NULL) {
 	        text_color_set(DW_COLOR_ERROR);
 		dw_printf("FX.25 internal error: init_rs_char failed!\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
 		exit(EXIT_FAILURE);
 	  }
 	}

--- a/src/fx25_rec.c
+++ b/src/fx25_rec.c
@@ -85,6 +85,7 @@ int main ()
 	    dw_printf ("\n");
 	    dw_printf ("****** Could not open %s ******\n", fname);
 	    dw_printf ("****** Did you generate the test files first? ******\n");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (EXIT_FAILURE);
 	  }
 
@@ -110,12 +111,14 @@ int main ()
 	  dw_printf ("\n");
 	  dw_printf ("\n");
 	  dw_printf ("***** FX25 unit test Success - all tests passed. *****\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_SUCCESS);
 	}
 	text_color_set(DW_COLOR_ERROR);
 	dw_printf ("\n");
 	dw_printf ("\n");
 	dw_printf ("***** FX25 unit test FAILED.  Only %d/11 tests passed. *****\n", fx25_test_count);
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 
 } // end main 

--- a/src/fx25_rec.c
+++ b/src/fx25_rec.c
@@ -484,3 +484,4 @@ static int my_unstuff (int chan, int subchan, int slice, unsigned char * restric
 }  // my_unstuff
 
 // end fx25_rec.c
+

--- a/src/fx25_rec.c
+++ b/src/fx25_rec.c
@@ -483,5 +483,5 @@ static int my_unstuff (int chan, int subchan, int slice, unsigned char * restric
 
 }  // my_unstuff
 
-// end fx25_rec.c
 
+// end fx25_rec.c

--- a/src/fx25_send.c
+++ b/src/fx25_send.c
@@ -335,3 +335,4 @@ static int stuff_it (unsigned char *in, int ilen, unsigned char *out, int osize)
 } // end stuff_it
 
 // end fx25_send.c
+

--- a/src/fx25_send.c
+++ b/src/fx25_send.c
@@ -64,6 +64,7 @@ int main ()
 	for (int i = 100 + CTAG_MIN; i <= 100 + CTAG_MAX; i++) {
 	  fx25_send_frame (0, preload, (int)sizeof(preload)-3, i);
 	}
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit(EXIT_SUCCESS);
 } // end main
 #endif

--- a/src/fx25_send.c
+++ b/src/fx25_send.c
@@ -335,4 +335,3 @@ static int stuff_it (unsigned char *in, int ilen, unsigned char *out, int osize)
 } // end stuff_it
 
 // end fx25_send.c
-

--- a/src/gen_packets.c
+++ b/src/gen_packets.c
@@ -718,7 +718,7 @@ static void usage (char **argv)
 	dw_printf ("\n");
         dw_printf ("    Read message from stdin and put quarter volume sound into the file x.wav.\n");
 
-        dw_printf ("\e[0m\e\n\e[0J\e");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_FAILURE);
 }
 

--- a/src/gen_packets.c
+++ b/src/gen_packets.c
@@ -252,6 +252,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].baud < MIN_BAUD || modem.achan[0].baud > MAX_BAUD) {
                 text_color_set(DW_COLOR_ERROR);
                 dw_printf ("Use a more reasonable bit rate in range of %d - %d.\n", MIN_BAUD, MAX_BAUD);
+		dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -272,6 +273,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].baud != 100 && (modem.achan[0].baud < MIN_BAUD || modem.achan[0].baud > MAX_BAUD)) {
                 text_color_set(DW_COLOR_ERROR);
                 dw_printf ("Use a more reasonable bit rate in range of %d - %d.\n", MIN_BAUD, MAX_BAUD);
+		dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
 
@@ -343,6 +345,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].mark_freq < 300 || modem.achan[0].mark_freq > 3000) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Use a more reasonable value in range of 300 - 3000.\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -355,6 +358,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].space_freq < 300 || modem.achan[0].space_freq > 3000) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Use a more reasonable value in range of 300 - 3000.\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -379,6 +383,7 @@ int main(int argc, char **argv)
               if (amplitude < 0 || amplitude > 200) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Amplitude must be in range of 0 to 200.\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -392,6 +397,7 @@ int main(int argc, char **argv)
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Use a more reasonable audio sample rate in range of %d - %d.\n",
 						MIN_SAMPLES_PER_SEC, MAX_SAMPLES_PER_SEC);
+		dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -410,6 +416,7 @@ int main(int argc, char **argv)
               if (leading_zeros < 8 || leading_zeros > 12000) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Use a more reasonable value.\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -447,6 +454,7 @@ int main(int argc, char **argv)
               if (g_morse_wpm < 5 || g_morse_wpm > 50) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Morse code speed must be in range of 5 to 50 WPM.\n");
+		dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -504,6 +512,7 @@ int main(int argc, char **argv)
           text_color_set(DW_COLOR_ERROR);
           dw_printf ("ERROR: Either -j or -J must be specified when using 2400 bps QPSK.\n");
           usage (argv);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
           exit (1);
 	}
 
@@ -515,6 +524,7 @@ int main(int argc, char **argv)
           text_color_set(DW_COLOR_ERROR); 
           dw_printf ("ERROR: The -o output file option must be specified.\n");
           usage (argv);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
           exit (1);
         }
 
@@ -524,6 +534,7 @@ int main(int argc, char **argv)
         if (err < 0) {
           text_color_set(DW_COLOR_ERROR); 
           dw_printf ("ERROR - Can't open output file.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
           exit (1);
         }
 
@@ -571,6 +582,7 @@ int main(int argc, char **argv)
             if (input_fp == NULL) {
               text_color_set(DW_COLOR_ERROR); 
  	      dw_printf ("Can't open %s for read.\n", argv[optind]);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
               exit (EXIT_FAILURE);
             }
             text_color_set(DW_COLOR_INFO); 
@@ -706,6 +718,7 @@ static void usage (char **argv)
 	dw_printf ("\n");
         dw_printf ("    Read message from stdin and put quarter volume sound into the file x.wav.\n");
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_FAILURE);
 }
 

--- a/src/gen_packets.c
+++ b/src/gen_packets.c
@@ -252,7 +252,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].baud < MIN_BAUD || modem.achan[0].baud > MAX_BAUD) {
                 text_color_set(DW_COLOR_ERROR);
                 dw_printf ("Use a more reasonable bit rate in range of %d - %d.\n", MIN_BAUD, MAX_BAUD);
-	        dw_printf ("\e[0m\e\n\e[0J\e");
+                dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].baud != 100 && (modem.achan[0].baud < MIN_BAUD || modem.achan[0].baud > MAX_BAUD)) {
                 text_color_set(DW_COLOR_ERROR);
                 dw_printf ("Use a more reasonable bit rate in range of %d - %d.\n", MIN_BAUD, MAX_BAUD);
-	        dw_printf ("\e[0m\e\n\e[0J\e");
+                dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
 
@@ -581,7 +581,7 @@ int main(int argc, char **argv)
             input_fp = fopen(argv[optind], "r");
             if (input_fp == NULL) {
               text_color_set(DW_COLOR_ERROR); 
- 	      dw_printf ("Can't open %s for read.\n", argv[optind]);
+              dw_printf ("Can't open %s for read.\n", argv[optind]);
               dw_printf ("\e[0m\e\n\e[0J\e");
               exit (EXIT_FAILURE);
             }

--- a/src/gen_packets.c
+++ b/src/gen_packets.c
@@ -252,7 +252,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].baud < MIN_BAUD || modem.achan[0].baud > MAX_BAUD) {
                 text_color_set(DW_COLOR_ERROR);
                 dw_printf ("Use a more reasonable bit rate in range of %d - %d.\n", MIN_BAUD, MAX_BAUD);
-		dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].baud != 100 && (modem.achan[0].baud < MIN_BAUD || modem.achan[0].baud > MAX_BAUD)) {
                 text_color_set(DW_COLOR_ERROR);
                 dw_printf ("Use a more reasonable bit rate in range of %d - %d.\n", MIN_BAUD, MAX_BAUD);
-		dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
 
@@ -345,7 +345,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].mark_freq < 300 || modem.achan[0].mark_freq > 3000) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Use a more reasonable value in range of 300 - 3000.\n");
-		dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -358,7 +358,7 @@ int main(int argc, char **argv)
               if (modem.achan[0].space_freq < 300 || modem.achan[0].space_freq > 3000) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Use a more reasonable value in range of 300 - 3000.\n");
-		dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -383,7 +383,7 @@ int main(int argc, char **argv)
               if (amplitude < 0 || amplitude > 200) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Amplitude must be in range of 0 to 200.\n");
-		dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -397,7 +397,7 @@ int main(int argc, char **argv)
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Use a more reasonable audio sample rate in range of %d - %d.\n",
 						MIN_SAMPLES_PER_SEC, MAX_SAMPLES_PER_SEC);
-		dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -416,7 +416,7 @@ int main(int argc, char **argv)
               if (leading_zeros < 8 || leading_zeros > 12000) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Use a more reasonable value.\n");
-		dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -454,7 +454,7 @@ int main(int argc, char **argv)
               if (g_morse_wpm < 5 || g_morse_wpm > 50) {
                 text_color_set(DW_COLOR_ERROR); 
 	        dw_printf ("Morse code speed must be in range of 5 to 50 WPM.\n");
-		dw_printf ("\e[0m\e\n\e[0J\e");
+	        dw_printf ("\e[0m\e\n\e[0J\e");
                 exit (EXIT_FAILURE);
               }
               break;
@@ -512,7 +512,7 @@ int main(int argc, char **argv)
           text_color_set(DW_COLOR_ERROR);
           dw_printf ("ERROR: Either -j or -J must be specified when using 2400 bps QPSK.\n");
           usage (argv);
-	  dw_printf ("\e[0m\e\n\e[0J\e");
+          dw_printf ("\e[0m\e\n\e[0J\e");
           exit (1);
 	}
 
@@ -524,7 +524,7 @@ int main(int argc, char **argv)
           text_color_set(DW_COLOR_ERROR); 
           dw_printf ("ERROR: The -o output file option must be specified.\n");
           usage (argv);
-	  dw_printf ("\e[0m\e\n\e[0J\e");
+          dw_printf ("\e[0m\e\n\e[0J\e");
           exit (1);
         }
 
@@ -534,7 +534,7 @@ int main(int argc, char **argv)
         if (err < 0) {
           text_color_set(DW_COLOR_ERROR); 
           dw_printf ("ERROR - Can't open output file.\n");
-	  dw_printf ("\e[0m\e\n\e[0J\e");
+          dw_printf ("\e[0m\e\n\e[0J\e");
           exit (1);
         }
 
@@ -582,7 +582,7 @@ int main(int argc, char **argv)
             if (input_fp == NULL) {
               text_color_set(DW_COLOR_ERROR); 
  	      dw_printf ("Can't open %s for read.\n", argv[optind]);
-	      dw_printf ("\e[0m\e\n\e[0J\e");
+              dw_printf ("\e[0m\e\n\e[0J\e");
               exit (EXIT_FAILURE);
             }
             text_color_set(DW_COLOR_INFO); 
@@ -718,7 +718,7 @@ static void usage (char **argv)
 	dw_printf ("\n");
         dw_printf ("    Read message from stdin and put quarter volume sound into the file x.wav.\n");
 
-	dw_printf ("\e[0m\e\n\e[0J\e");
+        dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_FAILURE);
 }
 

--- a/src/gen_tone.c
+++ b/src/gen_tone.c
@@ -418,6 +418,7 @@ void tone_gen_put_bit (int chan, int dat)
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("INTERNAL ERROR: %s %d achan[%d].modem_type = %d\n",
 				__FILE__, __LINE__, chan, save_audio_config_p->achan[chan].modem_type);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 	  }
 

--- a/src/igate.c
+++ b/src/igate.c
@@ -837,6 +837,7 @@ static void * connnect_thread (void *arg)
 	  }
 	}
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit(0);	// Unreachable but stops compiler from complaining
 			// about function not returning a value.
 } /* end connnect_thread */

--- a/src/kiss_frame.c
+++ b/src/kiss_frame.c
@@ -987,6 +987,7 @@ int main ()
 	assert (memcmp(din, dout, 512) == 0);
 
 	dw_printf ("Quick KISS test passed OK.\n");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 }
 

--- a/src/kissutil.c
+++ b/src/kissutil.c
@@ -269,14 +269,14 @@ int main (int argc, char *argv[])
 	    if ( ! S_ISDIR(s.st_mode)) {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf ("Receive queue location, %s, is not a directory.\n", receive_output);
-	      dw_printf ("\e[0m\e\n\e[0J\e");
+              dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 	    }
 	  }
 	  else {
 	    text_color_set(DW_COLOR_ERROR);
             dw_printf ("Receive queue location, %s, does not exist.\n", receive_output);
-	    dw_printf ("\e[0m\e\n\e[0J\e");
+            dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (EXIT_FAILURE);
 	  }
 	}
@@ -366,7 +366,7 @@ int main (int argc, char *argv[])
 	    else {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf("Can't access transmit queue directory %s.  Quitting.\n", transmit_from);
-	      dw_printf ("\e[0m\e\n\e[0J\e");
+              dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 	    }
 	    SLEEP_SEC (1);

--- a/src/kissutil.c
+++ b/src/kissutil.c
@@ -269,12 +269,14 @@ int main (int argc, char *argv[])
 	    if ( ! S_ISDIR(s.st_mode)) {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf ("Receive queue location, %s, is not a directory.\n", receive_output);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 	    }
 	  }
 	  else {
 	    text_color_set(DW_COLOR_ERROR);
             dw_printf ("Receive queue location, %s, does not exist.\n", receive_output);
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (EXIT_FAILURE);
 	  }
 	}
@@ -293,6 +295,7 @@ int main (int argc, char *argv[])
 	}
 	if (tnc_th == NULL) {
 	  printf ("Internal error: Could not create TNC listen thread.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 #else
@@ -304,6 +307,7 @@ int main (int argc, char *argv[])
 	}
 	if (e != 0) {
 	  perror("Internal error: Could not create TNC listen thread.");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 #endif
@@ -362,6 +366,7 @@ int main (int argc, char *argv[])
 	    else {
 	      text_color_set(DW_COLOR_ERROR);
               dw_printf("Can't access transmit queue directory %s.  Quitting.\n", transmit_from);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (EXIT_FAILURE);
 	    }
 	    SLEEP_SEC (1);
@@ -625,6 +630,7 @@ static THREAD_F tnc_listen_net (void *arg)
 	if (err < 0) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Network interface failure.  Can't go on.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 	
@@ -639,6 +645,7 @@ static THREAD_F tnc_listen_net (void *arg)
 	if (server_sock == -1) {
 	  text_color_set(DW_COLOR_ERROR);
 	  // Should have been a message already.  What else is there to say?
+	  dw_printf ("\e[0m\e\n\e[0J\e");
  	  exit (EXIT_FAILURE);
 	}
 
@@ -669,6 +676,7 @@ static THREAD_F tnc_listen_net (void *arg)
 
 	text_color_set(DW_COLOR_ERROR);
 	dw_printf ("Read error from TCP KISS TNC.  Terminating.\n");
+	dw_printf ("\e[0m\e\n\e[0J\e");
  	exit (EXIT_FAILURE);
 
 } /* end tnc_listen_net */
@@ -707,6 +715,7 @@ static THREAD_F tnc_listen_serial (void *arg)
 	  // More detail such as "permission denied" or "no such device"
 	  dw_printf("%s\n", strerror(errno));
 #endif
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
@@ -720,6 +729,7 @@ static THREAD_F tnc_listen_serial (void *arg)
 
 	  if (ch < 0) {
  	    dw_printf("Read error from serial port KISS TNC.\n");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (EXIT_FAILURE);
 	  }
 
@@ -919,6 +929,7 @@ static void usage(void)
 	dw_printf ("	-o	Receive output queue directory.  Store received frames here.\n");
 	dw_printf ("	-T	Precede received frames with 'strftime' format time stamp.\n");
 	usage2();
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 }
 

--- a/src/latlong.c
+++ b/src/latlong.c
@@ -1048,4 +1048,3 @@ int main (int argc, char *argv[])
 
 
 /* end latlong.c */
-

--- a/src/latlong.c
+++ b/src/latlong.c
@@ -1032,10 +1032,12 @@ int main (int argc, char *argv[])
         if (errors > 0) {
           text_color_set (DW_COLOR_ERROR);
           dw_printf ("\nLocation Coordinate Conversion Test - FAILED!\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
           exit (EXIT_FAILURE);
         }
         text_color_set (DW_COLOR_REC);
         dw_printf ("\nLocation Coordinate Conversion Test - SUCCESS!\n");
+	dw_printf ("\e[0m\e\n\e[0J\e");
         exit (EXIT_SUCCESS);
 
 }

--- a/src/latlong.c
+++ b/src/latlong.c
@@ -1032,12 +1032,12 @@ int main (int argc, char *argv[])
         if (errors > 0) {
           text_color_set (DW_COLOR_ERROR);
           dw_printf ("\nLocation Coordinate Conversion Test - FAILED!\n");
-	  dw_printf ("\e[0m\e\n\e[0J\e");
+          dw_printf ("\e[0m\e\n\e[0J\e");
           exit (EXIT_FAILURE);
         }
         text_color_set (DW_COLOR_REC);
         dw_printf ("\nLocation Coordinate Conversion Test - SUCCESS!\n");
-	dw_printf ("\e[0m\e\n\e[0J\e");
+        dw_printf ("\e[0m\e\n\e[0J\e");
         exit (EXIT_SUCCESS);
 
 }
@@ -1048,3 +1048,4 @@ int main (int argc, char *argv[])
 
 
 /* end latlong.c */
+

--- a/src/ll2utm.c
+++ b/src/ll2utm.c
@@ -116,3 +116,4 @@ static void usage (void)
 	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (1);
 }
+

--- a/src/ll2utm.c
+++ b/src/ll2utm.c
@@ -94,6 +94,7 @@ int main (int argc, char *argv[])
 	  fprintf (stderr, "Conversion to USNG failed:\n%s\n", message);
 	}
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (0);
 }
 
@@ -112,5 +113,6 @@ static void usage (void)
 	fprintf (stderr, "Example:\n");
 	fprintf (stderr, "\tll2utm 42.662139 -71.365553\n");
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (1);
 }

--- a/src/ll2utm.c
+++ b/src/ll2utm.c
@@ -116,4 +116,3 @@ static void usage (void)
 	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (1);
 }
-

--- a/src/log2gpx.c
+++ b/src/log2gpx.c
@@ -94,7 +94,7 @@ int main (int argc, char *argv[])
 	      }
 	      else {
 	        fprintf (stderr, "Can't open %s for read.\n", argv[n]);
-		dw_printf ("\e[0m\e\n\e[0J\e");
+		printf ("\e[0m\e\n\e[0J\e");
 	        exit (1);
 	      }
 	    }
@@ -103,7 +103,7 @@ int main (int argc, char *argv[])
 	
 	if (num_things == 0) {
 	  fprintf (stderr, "Nothing to process.\n");
-	  dw_printf ("\e[0m\e\n\e[0J\e");
+	  printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -147,8 +147,8 @@ int main (int argc, char *argv[])
  *  GPX file tail.
  */
 	printf ("</gpx>\n");
+	printf ("\e[0m\e\n\e[0J\e");
 
-	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (0);
 }
 

--- a/src/log2gpx.c
+++ b/src/log2gpx.c
@@ -94,7 +94,7 @@ int main (int argc, char *argv[])
 	      }
 	      else {
 	        fprintf (stderr, "Can't open %s for read.\n", argv[n]);
-		printf ("\e[0m\e\n\e[0J\e");
+	        printf ("\e[0m\e\n\e[0J\e");
 	        exit (1);
 	      }
 	    }

--- a/src/log2gpx.c
+++ b/src/log2gpx.c
@@ -94,6 +94,7 @@ int main (int argc, char *argv[])
 	      }
 	      else {
 	        fprintf (stderr, "Can't open %s for read.\n", argv[n]);
+		dw_printf ("\e[0m\e\n\e[0J\e");
 	        exit (1);
 	      }
 	    }
@@ -102,6 +103,7 @@ int main (int argc, char *argv[])
 	
 	if (num_things == 0) {
 	  fprintf (stderr, "Nothing to process.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -146,6 +148,7 @@ int main (int argc, char *argv[])
  */
 	printf ("</gpx>\n");
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (0);
 }
 

--- a/src/multi_modem.c
+++ b/src/multi_modem.c
@@ -256,6 +256,7 @@ void multi_modem_process_sample (int chan, int audio_sample)
 									save_audio_config_p->achan[chan].num_subchan, MAX_SUBCHANS,
 									save_audio_config_p->achan[chan].num_slicers, MAX_SLICERS);
 	  dw_printf ("Please report this message and include a copy of your configuration file.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 

--- a/src/pfilter.c
+++ b/src/pfilter.c
@@ -1737,10 +1737,12 @@ int main ()
 	if (error_count > 0) {
 	  text_color_set (DW_COLOR_ERROR);
 	  dw_printf ("\nPacket Filtering Test - FAILED!\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 	text_color_set (DW_COLOR_REC);
 	dw_printf ("\nPacket Filtering Test - SUCCESS!\n");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 
 }

--- a/src/ptt.c
+++ b/src/ptt.c
@@ -257,6 +257,7 @@ static void get_access_to_gpio (const char *path)
 	  dw_printf ("Can't get properties of %s.\n", path);
 	  dw_printf ("This system is not configured with the GPIO user interface.\n");
 	  dw_printf ("Use a different method for PTT control.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -376,6 +377,7 @@ static void get_access_to_gpio (const char *path)
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("This system is not configured with the GPIO user interface.\n");
 	  dw_printf ("Use a different method for PTT control.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -390,6 +392,7 @@ static void get_access_to_gpio (const char *path)
 	  dw_printf (" 3. Configure your user id for sudo without a password.\n");
 	  dw_printf ("\n");
 	  dw_printf ("Read the documentation and try -doo command line option for debugging details.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -452,6 +455,7 @@ void export_gpio(int ch, int ot, int invert, int direction)
 	  // Not expected.  Above should have obtained permission or exited.
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Permissions do not allow access to GPIO.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -464,6 +468,7 @@ void export_gpio(int ch, int ot, int invert, int direction)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("Error writing \"%s\" to %s, errno=%d\n", stemp, gpio_export_path, e);
 	    dw_printf ("%s\n", strerror(e));
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 	}
@@ -574,6 +579,7 @@ void export_gpio(int ch, int ot, int invert, int direction)
 
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("ERROR! Could not find Path for gpio number %d.n", gpio_num);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -590,6 +596,7 @@ void export_gpio(int ch, int ot, int invert, int direction)
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Error opening %s\n", stemp);
 	  dw_printf ("%s\n", strerror(e));
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -610,6 +617,7 @@ void export_gpio(int ch, int ot, int invert, int direction)
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Error writing initial state to %s\n", stemp);
 	  dw_printf ("%s\n", strerror(e));
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 	close (fd);

--- a/src/recv.c
+++ b/src/recv.c
@@ -165,6 +165,7 @@ void recv_init (struct audio_s *pa)
 	    if (xmit_th[a] == NULL) {
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("FATAL: Could not create audio receive thread for device %d.\n", a);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit(1);
 	    }
 #else
@@ -174,6 +175,7 @@ void recv_init (struct audio_s *pa)
 	    if (e != 0) {
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("FATAL: Could not create audio receive thread for device %d.\n", a);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit(1);
 	    }
 #endif
@@ -278,6 +280,7 @@ static void * recv_adev_thread (void *arg)
 
 	text_color_set(DW_COLOR_ERROR);
 	dw_printf ("Terminating after audio input failure.\n");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (1);
 }
 

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -1377,11 +1377,13 @@ int main ( )
 	if (errors != 0) {
 	  text_color_set (DW_COLOR_ERROR);
 	  dw_printf ("\nTEST FAILED with %d errors.\n", errors);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
 	text_color_set (DW_COLOR_REC);
 	dw_printf ("\nTEST WAS SUCCESSFUL.\n");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 }
 

--- a/src/tq.c
+++ b/src/tq.c
@@ -155,6 +155,7 @@ void tq_init (struct audio_s *audio_config_p)
 	    if (wake_up_event[c] == NULL) {
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("tq_init: CreateEvent: can't create transmit wake up event, c=%d", c);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    }	
 	  }
@@ -173,6 +174,7 @@ void tq_init (struct audio_s *audio_config_p)
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("tq_init: pthread_cond_init c=%d err=%d", c, err);
 	      perror ("");
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    }
 
@@ -333,6 +335,7 @@ void tq_append (int chan, int prio, packet_t pp)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("tq_append: pthread_cond_signal err=%d", err);
 	    perror ("");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 
@@ -526,6 +529,7 @@ void lm_data_request (int chan, int prio, packet_t pp)
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("lm_data_request: pthread_cond_signal err=%d", err);
 	      perror ("");
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    }
 
@@ -673,6 +677,7 @@ void lm_seize_request (int chan)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("lm_seize_request: pthread_cond_signal err=%d", err);
 	    perror ("");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 
@@ -763,6 +768,7 @@ void tq_wait_while_empty (int chan)
 	    text_color_set(DW_COLOR_ERROR);
 	    dw_printf ("tq_wait_while_empty (%d): pthread_cond_wait err=%d", chan, err);
 	    perror ("");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 

--- a/src/tt_text.c
+++ b/src/tt_text.c
@@ -1600,6 +1600,7 @@ int main (int argc, char *argv[])
 	if (argc < 2) {
 	  text_color_set (DW_COLOR_ERROR);
 	  dw_printf ("Supply text string on command line.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -1667,6 +1668,7 @@ int main (int argc, char *argv[])
 	if (argc < 2) {
 	  text_color_set (DW_COLOR_ERROR);
 	  dw_printf ("Supply button sequence on command line.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -1812,11 +1814,13 @@ int main (int argc, char *argv[])
 
 	  text_color_set (DW_COLOR_ERROR);
 	  dw_printf ("\nERROR: %d tests failed.\n", error_count);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);
 	}
 
 	text_color_set (DW_COLOR_REC);
 	dw_printf ("\nSUCCESS!  All tests passed.\n");
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 
 

--- a/src/ttcalc.c
+++ b/src/ttcalc.c
@@ -127,6 +127,7 @@ int main (int argc, char *argv[])
 
 
 	if (server_sock == -1) {
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (1);
 	}
 
@@ -154,6 +155,7 @@ int main (int argc, char *argv[])
 
 	  if (n != sizeof(mon_cmd)) {
 	    printf ("Read error, received %d command bytes.\n", n);
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	  }
 
@@ -164,6 +166,7 @@ int main (int argc, char *argv[])
 
 	    if (n != mon_cmd.data_len) {
 	      printf ("Read error, client received %d data bytes when %d expected.  Terminating.\n", n, mon_cmd.data_len);
+	      dw_printf ("\e[0m\e\n\e[0J\e");
 	      exit (1);
 	    }
 	  }
@@ -364,12 +367,14 @@ static int connect_to_server (char *hostname, char *port)
 	err = WSAStartup (MAKEWORD(2,2), &wsadata);
 	if (err != 0) {
 	    printf("WSAStartup failed: %d\n", err);
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (1);
 	}
 
 	if (LOBYTE(wsadata.wVersion) != 2 || HIBYTE(wsadata.wVersion) != 2) {
           printf("Could not find a usable version of Winsock.dll\n");
           WSACleanup();
+	  dw_printf ("\e[0m\e\n\e[0J\e");
           exit (1);
 	}
 #endif
@@ -394,6 +399,7 @@ static int connect_to_server (char *hostname, char *port)
 	  printf ("Can't get address for server %s, %s\n", hostname, gai_strerror(err));
 #endif
 	  freeaddrinfo(ai_head);
+	  dw_printf ("\e[0m\e\n\e[0J\e");
       	  exit (1);
 	}
 

--- a/src/utm2ll.c
+++ b/src/utm2ll.c
@@ -145,3 +145,4 @@ static void usage (void)
 	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (1);
 }
+

--- a/src/utm2ll.c
+++ b/src/utm2ll.c
@@ -115,6 +115,7 @@ int main (int argc, char *argv[])
 	  usage();
 	}
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (0);
 }
 
@@ -141,5 +142,6 @@ static void usage (void)
 	fprintf (stderr, "\tutm2ll 19T 306130 4726010\n");
 	fprintf (stderr, "\tutm2ll 19TCH06132600\n");
 
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (1);
 }

--- a/src/utm2ll.c
+++ b/src/utm2ll.c
@@ -145,4 +145,3 @@ static void usage (void)
 	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (1);
 }
-

--- a/src/walk96.c
+++ b/src/walk96.c
@@ -76,7 +76,7 @@ int main (int argc, char *argv[])
 	if (tnc == MYFDERROR) {
 	  text_color_set (DW_COLOR_ERROR);
           dw_printf ("Can't open serial port to KISS TNC.\n");
-	  dw_printf ("\e[0m\e\n\e[0J\e");
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);	// defined in stdlib.h
   	}
 
@@ -106,7 +106,7 @@ int main (int argc, char *argv[])
 	  else if (fix < 0) {
 	    text_color_set (DW_COLOR_ERROR);
             dw_printf ("Can't communicate with GPS receiver.\n");
-	    dw_printf ("\e[0m\e\n\e[0J\e");
+            dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (EXIT_FAILURE);
 	  }
 	  else  {
@@ -180,7 +180,7 @@ static void walk96 (int fix, double lat, double lon, float knots, float course, 
 	if (pp == NULL) {
 	  text_color_set (DW_COLOR_ERROR);
           dw_printf ("Unexpected error in ax25_from_text.  Quitting.\n");
-	  dw_printf ("\e[0m\e\n\e[0J\e");
+          dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);	// defined in stdlib.h
 	}
 

--- a/src/walk96.c
+++ b/src/walk96.c
@@ -76,6 +76,7 @@ int main (int argc, char *argv[])
 	if (tnc == MYFDERROR) {
 	  text_color_set (DW_COLOR_ERROR);
           dw_printf ("Can't open serial port to KISS TNC.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);	// defined in stdlib.h
   	}
 
@@ -105,6 +106,7 @@ int main (int argc, char *argv[])
 	  else if (fix < 0) {
 	    text_color_set (DW_COLOR_ERROR);
             dw_printf ("Can't communicate with GPS receiver.\n");
+	    dw_printf ("\e[0m\e\n\e[0J\e");
 	    exit (EXIT_FAILURE);
 	  }
 	  else  {
@@ -120,6 +122,7 @@ int main (int argc, char *argv[])
 	serial_port_write (tnc, "\xc0\xff\xc0", 3);
 
 	SLEEP_MS(100);
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (EXIT_SUCCESS);
 }
 
@@ -177,6 +180,7 @@ static void walk96 (int fix, double lat, double lon, float knots, float course, 
 	if (pp == NULL) {
 	  text_color_set (DW_COLOR_ERROR);
           dw_printf ("Unexpected error in ax25_from_text.  Quitting.\n");
+	  dw_printf ("\e[0m\e\n\e[0J\e");
 	  exit (EXIT_FAILURE);	// defined in stdlib.h
 	}
 

--- a/src/xid.c
+++ b/src/xid.c
@@ -828,6 +828,7 @@ int main (int argc, char *argv[]) {
 	text_color_set (DW_COLOR_REC);
 	dw_printf ("XID test:  Success.\n");	
 	
+	dw_printf ("\e[0m\e\n\e[0J\e");
 	exit (0);
 	
 }


### PR DESCRIPTION
The background colour of the user's terminal is restored on quit, but Direwolf output is unaffected. The following screenshot shows the changes made.
![2022-03-22_02:20:28](https://user-images.githubusercontent.com/95985845/159448186-6f58dbda-8950-481f-97d4-5483680d0aa0.png)
