### PR TITLE
Fix spelling errors

### DIFF
--- a/src/appserver.c
+++ b/src/appserver.c
@@ -320,7 +320,7 @@ static void poll_timing_test (void)
  *
  *		data		- Should look something like this for incoming:
  *					*** CONNECTED to Station xxx\r
- *				  and ths for my request being accepted:
+ *				  and this for my request being accepted:
  *					*** CONNECTED With Station xxx\r
  *
  *		session_id	- Session id to be used in data transfer and

--- a/src/audio.c
+++ b/src/audio.c
@@ -821,7 +821,7 @@ static int poll_sndio (struct sio_hdl *hdl, int events)
 	  revents = sio_revents (hdl, pfds);
 	} while (!(revents & (events | POLLHUP)));
 
-	/* unrecoverable error occured */
+	/* unrecoverable error occurred */
 	if (revents & POLLHUP) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("waited for %s, POLLHUP received\n", (events & POLLIN) ? "POLLIN" : "POLLOUT");

--- a/src/cm108.c
+++ b/src/cm108.c
@@ -304,7 +304,7 @@ static void usage(void)
 	dw_printf ("which ones can be used for GPIO PTT.\n");
 #endif
 	dw_printf ("\n");
-	dw_printf ("Specify the HID device path to test the PTT fuction.\n");
+	dw_printf ("Specify the HID device path to test the PTT function.\n");
 	dw_printf ("Its state should change once per second.\n");
 #if __WIN32__
 	dw_printf ("You might need to quote the path depending on the command processor.\n");
@@ -854,7 +854,7 @@ void cm108_find_ptt (char *output_audio_device, char *ptt_device,  int ptt_devic
  *
  * Future:	For our initial implementation we are making the simplifying
  *		restriction of using only one GPIO pin per device and limit
- *		configuratin to PTT only.
+ *		configuration to PTT only.
  *		Longer term, we might want to have DCD, and maybe other
  *		controls thru the same chip.
  *		In this case, we would need to retain bit masks for each

--- a/src/decode_aprs.c
+++ b/src/decode_aprs.c
@@ -213,7 +213,7 @@ void decode_aprs (decode_aprs_t *A, packet_t pp, int quiet, int third_party)
 	  // This must not be strict because the addresses in third party payload doesn't
 	  // need to adhere to the AX.25 address format (i.e. 6 upper case alphanumeric.)
 	  // SSID can be 2 alphanumeric characters.
-	  // Addresses can include lower case, e.g. q contruct.
+	  // Addresses can include lower case, e.g. q construct.
 
 	  // e.g.  WR2X-2>APRS,WA1PLE-13*:}
 	  //		K1BOS-B>APOSB,TCPIP,WR2X-2*:@122015z4221.42ND07111.93W&/A=000000SharkRF openSPOT3 MMDVM446.025 MA/SW
@@ -1589,7 +1589,7 @@ static void aprs_message (decode_aprs_t *A, unsigned char *info, int ilen, int q
 	  char colon;			/* : */
 	  char message[256-1-9-1];	/* Officially up to 67 characters for message text. */
 					/* Relaxing seemingly arbitrary restriction here; it doesn't need to fit on a punched card. */
-					/* Wouldn't surprize me if others did not pay attention to the limit. */
+					/* Wouldn't surprise me if others did not pay attention to the limit. */
 					/* Optional { followed by 1-5 alphanumeric characters for message number */
 
 					/* If the first character is '?' it is a Directed Station Query. */

--- a/src/demod_9600.c
+++ b/src/demod_9600.c
@@ -133,7 +133,7 @@ static inline float agc (float in, float fast_attack, float slow_decay, float *p
  *		upsample	- Factor to upsample the incoming stream.
  *				  After a lot of experimentation, I discovered that
  *				  it works better if the data is upsampled.
- *				  This reduces the jitter for PLL syncronization.
+ *				  This reduces the jitter for PLL synchronization.
  *
  *		baud		- Data rate in bits per second.
  *
@@ -244,7 +244,7 @@ void demod_9600_init (enum modem_t modem_type, int original_sample_rate, int ups
 // Here is the general idea.
 //
 // Suppose the input samples are 1 2 3 4 5 6 7 8 9 ...
-// Filter coefficents are a b c d e f g h i ...
+// Filter coefficients are a b c d e f g h i ...
 //
 // With original sampling rate, the filtering would involve multiplying and adding:
 //

--- a/src/demod_afsk.c
+++ b/src/demod_afsk.c
@@ -588,7 +588,7 @@ void demod_afsk_init (int samples_per_sec, int baud, int mark_freq,
  *
  * First, let's take a look at Track 1 of the TNC test CD.  Here the receiver
  * has a flat response.  We find the mark/space strength ratios very from 0.53 to 1.38
- * with a median of 0.81.  This in in line with expections because most
+ * with a median of 0.81.  This is in line with expectations because most
  * transmitters add pre-emphasis to boost the higher audio frequencies.
  * Track 2 should more closely resemble what comes out of the speaker on a typical
  * transceiver.  Here we see a ratio from 1.73 to 3.81 with a median of 2.48.
@@ -706,7 +706,7 @@ void demod_afsk_process_sample (int chan, int subchan, int sam, struct demodulat
 	      // Rather than trying to find the best threshold location, use multiple 
 	      // slicer thresholds in parallel.
 	      // The best slicing point will vary from packet to packet but should
-	      // remain abount the same or a given packet.
+	      // remain about the same for a given packet.
 
 	      // We are not performing the AGC step here but still want the envelope
 	      // for caluculating the confidence level (or quality) of the sample.

--- a/src/dns_sd_avahi.c
+++ b/src/dns_sd_avahi.c
@@ -241,7 +241,7 @@ void dns_sd_announce (struct misc_config_s *mc)
         /* Allocate a new client */
         client = avahi_client_new(avahi_simple_poll_get(simple_poll), 0, client_callback, NULL, &error);
 
-        /* Check wether creating the client object succeeded */
+        /* Check whether creating the client object succeeded */
         if (!client) {
             text_color_set(DW_COLOR_ERROR);
             dw_printf(PRINT_PREFIX "Failed to create Avahi client: %s\n", avahi_strerror(error));

--- a/src/encode_aprs.c
+++ b/src/encode_aprs.c
@@ -125,7 +125,7 @@ static int set_norm_position (char symtab, char symbol, double dlat, double dlon
  *		height	- Feet.
  *		gain	- dBi.
  *
- * 		course	- Degress, 0 - 360 (360 equiv. to 0).  
+ * 		course	- Degrees, 0 - 360 (360 equiv. to 0).
  *			  Use G_UNKNOWN for none or unknown.
  *		speed	- knots.
  *
@@ -343,7 +343,7 @@ static int phg_data_extension (int power, int height, int gain, char *dir, char 
  *
  * Purpose:     Fill in parts of the course & speed data extension.
  *
- * Inputs: 	course	- Degress, 0 - 360 (360 equiv. to 0).
+ * Inputs: 	course	- Degrees, 0 - 360 (360 equiv. to 0).
  *			  Use G_UNKNOWN for none or unknown.
  *
  *		speed	- knots.
@@ -494,7 +494,7 @@ static int frequency_spec (float freq, float tone, float offset, char *presult)
  *		gain	- dB.  Not clear if it is dBi or dBd.
  *		dir	- Directivity: N, NE, etc., omni.
  *
- *		course	- Degress, 0 - 360 (360 equiv. to 0).
+ *		course	- Degrees, 0 - 360 (360 equiv. to 0).
  *			  Use G_UNKNOWN for none or unknown.
  *		speed	- knots.		// TODO:  should distinguish unknown(not revevant) vs. known zero.
  *
@@ -636,7 +636,7 @@ int encode_position (int messaging, int compressed, double lat, double lon, int 
  *		gain	- dB.  Not clear if it is dBi or dBd.
  *		dir	- Direction: N, NE, etc., omni.
  *
- *		course	- Degress, 0 - 360 (360 equiv. to 0).
+ *		course	- Degrees, 0 - 360 (360 equiv. to 0).
  *			  Use G_UNKNOWN for none or unknown.
  *		speed	- knots.
  *

--- a/src/il2p_codec.c
+++ b/src/il2p_codec.c
@@ -83,7 +83,7 @@ int il2p_encode_frame (packet_t pp, int max_fec, unsigned char *iout)
 	    out_len = IL2P_HEADER_SIZE + IL2P_HEADER_PARITY;
 
 	    if (e == 0) {
-	        // Sucess. No info part.
+	        // Success. No info part.
 	        return (out_len);
 	    }
 

--- a/src/il2p_header.c
+++ b/src/il2p_header.c
@@ -122,7 +122,7 @@ static int get_field (unsigned char *hdr, int bit_num, int lsb_index, int width)
 
 
 // AX.25 'I' and 'UI' frames have a protocol ID which determines how the
-// information part should be interpretted.
+// information part should be interpreted.
 // Here we squeeze the most common cases down to 4 bits.
 // Return -1 if translation is not possible.  Fall back to type 0 header in this case.
 
@@ -299,7 +299,7 @@ int il2p_type_1_header (packet_t pp, int max_fec, unsigned char *hdr)
 
 	        if (frame_type == frame_type_U_UI) {
 	            SET_UI(hdr, 1);	// I guess this is how we distinguish 'I' and 'UI'
-					// on the receving end.
+					// on the receiving end.
 	            int pid = encode_pid(pp);
 	            if (pid < 0) return (-1);
 	            SET_PID(hdr, pid);
@@ -320,7 +320,7 @@ int il2p_type_1_header (packet_t pp, int max_fec, unsigned char *hdr)
 		//	1	1	1	Not valid (earlier protocol version)
 		//
 		// APRS does not mention how to set these bits and all 4 combinations
-		// are seen in the wild.  Apparently these are ignord on receive and no
+		// are seen in the wild.  Apparently these are ignored on receive and no
 		// one cares.  Here we copy from the C bit in the destination address.
 		// It should be noted that the case of both C bits being the same can't
 		// be represented so the il2p encode/decode bit not produce exactly the

--- a/src/il2p_init.c
+++ b/src/il2p_init.c
@@ -157,7 +157,7 @@ void il2p_encode_rs (unsigned char *tx_data, int data_size, int num_parity, unsi
  *				data_size bytes.
  *
  * Returns:	-1 for unrecoverable.
- *		>= 0 for sucess.  Number of symbols corrected.
+ *		>= 0 for success.  Number of symbols corrected.
  *
  *--------------------------------------------------------------*/
 

--- a/src/il2p_payload.c
+++ b/src/il2p_payload.c
@@ -125,7 +125,7 @@ int il2p_payload_compute (il2p_payload_properties_t *p, int payload_size, int ma
  *		0 for no blocks.  (i.e. size zero)
  *		Number of bytes generated.  Maximum IL2P_MAX_ENCODED_SIZE.
  *
- * Note:	I interpretted the protocol spec as saying the LFSR state is retained
+ * Note:	I interpreted the protocol spec as saying the LFSR state is retained
  *		between data blocks.  During interoperability testing, I found that
  *		was not the case.  It is reset for each data block.
  *

--- a/src/il2p_test.c
+++ b/src/il2p_test.c
@@ -957,7 +957,7 @@ void multi_modem_process_rec_packet (int chan, int subchan, int slice, packet_t 
 	assert (strcmp(text, (char*)pinfo) == 0);
 
 	dw_printf ("Number of symbols corrected: %d\n", retries);
-	if (polarity == 2) {	// expecting errors corrrected.
+	if (polarity == 2) {	// expecting errors corrected.
 	    assert (retries == 10);
 	}
 	else {	// should be no errors.

--- a/src/kiss_frame.h
+++ b/src/kiss_frame.h
@@ -66,7 +66,7 @@ typedef struct kiss_frame_s {
 
 
 // This is used only for TCPKISS but it put in kissnet.h,
-// there would be a circular dependecy between the two header files.
+// there would be a circular dependency between the two header files.
 // Each KISS TCP port has its own status block.
 
 struct kissport_status_s {

--- a/src/mheard.c
+++ b/src/mheard.c
@@ -102,7 +102,7 @@ typedef struct mheard_s {
 
 	double dlat, dlon;			// Last position.  G_UNKNOWN for unknown.
 
-	int msp;				// Allow message sender positon report.
+	int msp;				// Allow message sender position report.
 						// When non zero, an IS>RF position report is allowed.
 						// Then decremented.
 
@@ -778,7 +778,7 @@ void mheard_set_msp (char *callsign, int num)
  *
  * Inputs:	callsign	- Callsign for station which sent the "message."
  *
- * Returns:	The cound for the specified station.
+ * Returns:	The count for the specified station.
  *		0 if not found.
  *
  *------------------------------------------------------------------*/

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -298,7 +298,7 @@ static const char *search_locations[] = {
  * Description:	The primary and alternate symbol tables are constant
  *		so they are hardcoded.
  *		However the "new" sysmbols, which give new meanings to
- *		overlayed symbols, are always evolving.
+ *		overlaid symbols, are always evolving.
  *		For maximum flexibility, we will read the
  *		data file at run time rather than compiling it in.
  *
@@ -386,7 +386,7 @@ void symbols_init (void)
 
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Warning: Could not open 'symbols-new.txt'.\n");
-	  dw_printf ("The \"new\" overlayed character information will not be available.\n");
+	  dw_printf ("The \"new\" overlaid character information will not be available.\n");
 
 	  new_sym_size = 1;	
 	  new_sym_ptr = calloc(new_sym_size, sizeof(new_sym_t));  /* Don't try again. */
@@ -681,7 +681,7 @@ void symbols_from_dest_or_src (char dti, char *src, char *dest, char *symtab, ch
 
 // The position and object formats all contain a proper symbol and table.
 // There doesn't seem to be much reason to have a symbol for something without
-// a postion because it would not show up on a map.
+// a position because it would not show up on a map.
 // This just seems to be a remnant of something used long ago and no longer needed.
 // The protocol spec mentions a "MIM tracker" but I can't find any references to it.
 

--- a/src/tnctest.c
+++ b/src/tnctest.c
@@ -615,7 +615,7 @@ void process_rec_data (int my_index, char *data)
  *				  and sent to a common function to check that they
  *				  all arrived in order.
  *
- * Global Out:	is_connected	- Updated when connected/disconnected notfications are received.
+ * Global Out:	is_connected	- Updated when connected/disconnected notifications are received.
  *
  * Description:	Perform any necessary configuration for the TNC then wait
  *		for responses and process them.
@@ -943,7 +943,7 @@ static void * tnc_thread_net (void *arg)
  *				  and sent to a common function to check that they
  *				  all arrived in order.
  *
- * Global Out:	is_connected	- Updated when connected/disconnected notfications are received.
+ * Global Out:	is_connected	- Updated when connected/disconnected notifications are received.
  *
  * Description:	Perform any necessary configuration for the TNC then wait
  *		for responses and process them.
@@ -1257,7 +1257,7 @@ static void tnc_send_data (int from, int to, char * data)
 	else {
 
 	  // The assumption is that we are in CONVERS mode.
-	  // The data sould be terminated by carriage return.
+	  // The data should be terminated by carriage return.
 
 	  int timeout = 600;	// 60 sec.  I've seen it take more than 20.
 	  while (timeout > 0 && busy[from]) {


### PR DESCRIPTION
Fixed with:
codespell --ignore-words-list=dout,feets,fo,inout,ist,ot,parm,usng src --write-changes --interactive=2
and manual editing.

I did not change the following words because OVERLAYED and Lightening are in the file `data/symbolsX.txt` and Pres and CONVERS seems to be false positives:
```
src/mgn_icon.h:211: OVERLAYED ==> OVERLAID
src/mgn_icon.h:213: HURICANE ==> HURRICANE
src/mgn_icon.h:223: Lightening ==> Lightning, lighting
src/mgn_icon.h:266: OVERLAYED ==> OVERLAID
src/mgn_icon.h:267: OVERLAYED ==> OVERLAID
src/mgn_icon.h:271: OVERLAYED ==> OVERLAID
src/grm_sym.h:436: OVERLAYED ==> OVERLAID
src/grm_sym.h:438: HURICANE ==> HURRICANE
src/grm_sym.h:448: Lightening ==> Lightning, lighting
src/grm_sym.h:491: OVERLAYED ==> OVERLAID
src/grm_sym.h:492: OVERLAYED ==> OVERLAID
src/grm_sym.h:496: OVERLAYED ==> OVERLAID
src/telemetry.c:1202: Pres ==> Press
src/telemetry.c:1210: Pres ==> Press
src/symbols.c:196: OVERLAYED ==> OVERLAID
src/symbols.c:198: HURICANE ==> HURRICANE
src/symbols.c:208: Lightening ==> Lightning, lighting
src/symbols.c:251: OVERLAYED ==> OVERLAID
src/symbols.c:252: OVERLAYED ==> OVERLAID
src/symbols.c:256: OVERLAYED ==> OVERLAID
src/tnctest.c:1259: CONVERS ==> CONVERSE, CONVERTS, CONVERT
```