### PR TITLE
Feature - Added channel INTERLOCK functionality

### DIFF
--- a/src/atest.c
+++ b/src/atest.c
@@ -86,6 +86,7 @@
 #include "hdlc_rec.h"
 
 
+
 #if 0	/* Typical but not flexible enough. */
 
 struct wav_header {             /* .WAV file header. */
@@ -898,6 +899,13 @@ void dlq_rec_frame (int chan, int subchan, int slice, packet_t pp, alevel_t alev
 	ax25_delete (pp);
 
 } /* end fake dlq_append */
+
+
+/* Fake is_channel_busy */
+int is_channel_busy(int chan) 
+{
+	return 0;
+}
 
 
 void ptt_set (int ot, int chan, int ptt_signal)

--- a/src/audio.h
+++ b/src/audio.h
@@ -245,6 +245,8 @@ struct audio_s {
 
 	    int passall;		/* Allow thru even with bad CRC. */
 
+	/* Interlock channels */
+	    int interlock;		/* Interlock number */
 
 
 	/* Additional properties for transmit. */
@@ -450,6 +452,14 @@ struct audio_s {
 #define DEFAULT_TXDELAY		30
 #define DEFAULT_TXTAIL		10	
 #define DEFAULT_FULLDUP		0
+
+/* 
+ * Interlocks are used to 'bind' channels together to share DCD and PTT signaling.
+ * Useful with several setup types where 2 or more channels shouldn't interfere with eachother.
+ * For example when radios and/or antennas are shared.
+ */
+ 
+#define MAX_INTERLOCKS		8
 
 /* 
  * Note that we have two versions of these in audio.c and audio_win.c.

--- a/src/ax25_link.c
+++ b/src/ax25_link.c
@@ -1998,6 +1998,25 @@ void lm_channel_busy (dlq_item_t *E)
 } /* end lm_channel_busy */
 
 
+/*------------------------------------------------------------------------------
+ *
+ * Name:	is_channel_busy
+ * 
+ * Purpose:	Returns DCD or PTT status for channel
+ *
+ * Inputs:	Channel
+ *
+ * Outputs:	True when busy, false when free
+ *
+ *------------------------------------------------------------------------------*/
+ 
+int is_channel_busy(int chan) 
+{
+	if (ptt_status[chan] || dcd_status[chan])
+	  return 1;
+
+	return 0;
+} /* end is_channel_busy */
 
 
 /*------------------------------------------------------------------------------

--- a/src/ax25_link.h
+++ b/src/ax25_link.h
@@ -76,6 +76,7 @@ void lm_seize_confirm (dlq_item_t *E);
 
 void lm_channel_busy (dlq_item_t *E);
 
+int is_channel_busy(int chan);
 
 void dl_timer_expiry (void);
 

--- a/src/config.c
+++ b/src/config.c
@@ -780,6 +780,8 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 	  p_audio_config->achan[channel].sanity_test = SANITY_APRS;
 	  p_audio_config->achan[channel].passall = 0;
 
+	  p_audio_config->achan[channel].interlock = 0;
+
 	  for (ot = 0; ot < NUM_OCTYPES; ot++) {
 	    p_audio_config->achan[channel].octrl[ot].ptt_method = PTT_METHOD_NONE;
 	    strlcpy (p_audio_config->achan[channel].octrl[ot].ptt_device, "", sizeof(p_audio_config->achan[channel].octrl[ot].ptt_device));
@@ -1729,6 +1731,31 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 	    }
 	  }
 
+/*
+ * INTERLOCK  n
+ *
+ * Interlocks channels with the same interlock number (n) to share DCD and PTT signaling.
+ */
+
+	  else if (strcasecmp(t, "INTERLOCK") == 0) {
+	    int n;
+	    t = split(NULL,0);
+	    if (t == NULL) {
+	      text_color_set(DW_COLOR_ERROR);
+	      dw_printf ("Line %d: Missing number for INTERLOCK command.\n", line);
+	      continue;
+	    }
+	    n = atoi(t);
+        if (n >= 0 && n <= MAX_INTERLOCKS) {
+	      p_audio_config->achan[channel].interlock = n;
+	    }
+	    else {
+	      p_audio_config->achan[channel].interlock = 0;
+	      text_color_set(DW_COLOR_ERROR);
+	      dw_printf ("Line %d: Invalid number for INTERLOCK. Using %d.\n",
+	                  line, p_audio_config->achan[channel].interlock);
+	     }
+	  }
 
 /*
  * PTT 		- Push To Talk signal line.

--- a/src/rrbb.c
+++ b/src/rrbb.c
@@ -101,7 +101,11 @@ rrbb_t rrbb_new (int chan, int subchan, int slice, int is_scrambled, int descram
 
 	new_count++;
 
-	if (new_count > delete_count + 100) {
+	/* 
+	  A value of delete_count + 100 seems to give issues with multiple channels and freq. offset decoding configured
+	  extended to 168 for testing a max. with 3 channels and 7 offset decoders p/channel
+	*/
+	if (new_count > delete_count + 168) {
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("MEMORY LEAK, rrbb_new, new_count=%d, delete_count=%d\n", new_count, delete_count);
 	}


### PR DESCRIPTION
Added feature to interlock channels with the same interlock number configured to share DCD and PTT signaling.
Useful with several setup types where 2 or more channels shouldn't interfere with eachother without the need to use TXINH and (external) connections and/or circuitry to accomplish similar goals. 

For example when radios and/or antennas are shared, or RX/TX more than 1 mode on a single soundcard and radio (with 'virtual Y-cable' setup) using multiple Direwolf channels.

Channels on the same INTERLOCK number configured are sharing DCD and PTT signaling internally.