### PR TITLE
Fix spelling errors

### DIFF
--- a/src/agwlib.c
+++ b/src/agwlib.c
@@ -365,7 +365,7 @@ static void * tnc_listen_thread (void *arg)
 	    }
 
 /*
- * Call to/from fields are 10 bytes but contents must not exceeed 9 characters.
+ * Call to/from fields are 10 bytes but contents must not exceed 9 characters.
  * It's not guaranteed that unused bytes will contain 0 so we
  * don't issue error message in this case. 
  */

--- a/src/audio.c
+++ b/src/audio.c
@@ -1532,7 +1532,7 @@ int audio_flush (int a)
  *		(3) Call this function, which might or might not wait long enough.
  *		(4) Add (1) and (2) resulting in when PTT should be turned off.
  *		(5) Take difference between current time and desired PPT off time
- *			and wait for additoinal time if required.
+ *			and wait for additional time if required.
  *
  *----------------------------------------------------------------*/
 

--- a/src/audio.h
+++ b/src/audio.h
@@ -72,7 +72,7 @@ struct audio_s {
 
 	struct adev_param_s {
 
-	    /* Properites of the sound device. */
+	    /* Properties of the sound device. */
 
 	    int defined;		/* Was device defined? */
 					/* First one defaults to yes. */
@@ -102,7 +102,7 @@ struct audio_s {
 					/* This is the probability, in per cent, of randomly corrupting it. */
 					/* Normally this is 0.  25 would mean corrupt it 25% of the time. */
 
-	int recv_error_rate;		/* Similar but the % probablity of dropping a received frame. */
+	int recv_error_rate;		/* Similar but the % probability of dropping a received frame. */
 
 	float recv_ber;			/* Receive Bit Error Rate (BER). */
 					/* Probability of inverting a bit coming out of the modem. */

--- a/src/audio_portaudio.c
+++ b/src/audio_portaudio.c
@@ -1260,7 +1260,7 @@ int audio_flush (int a)
  *		(3) Call this function, which might or might not wait long enough.
  *		(4) Add (1) and (2) resulting in when PTT should be turned off.
  *		(5) Take difference between current time and desired PPT off time
- *			and wait for additoinal time if required.
+ *			and wait for additional time if required.
  *
  *----------------------------------------------------------------*/
 

--- a/src/audio_win.c
+++ b/src/audio_win.c
@@ -84,7 +84,7 @@ static struct audio_s          *save_audio_config_p;
  */
 
 /*
- * Originally, we had an abitrary buf time of 40 mS.
+ * Originally, we had an arbitrary buf time of 40 mS.
  *
  * For mono, the buffer size was rounded up from 3528 to 4k so
  * it was really about 50 mS per buffer or about 20 per second.
@@ -1074,7 +1074,7 @@ int audio_flush (int a)
  *		(3) Call this function, which might or might not wait long enough.
  *		(4) Add (1) and (2) resulting in when PTT should be turned off.
  *		(5) Take difference between current time and desired PPT off time
- *			and wait for additoinal time if required.
+ *			and wait for additional time if required.
  *
  *----------------------------------------------------------------*/
 

--- a/src/ax25_link.c
+++ b/src/ax25_link.c
@@ -347,7 +347,7 @@ typedef struct ax25_dlsm_s {
 						// Sometimes the flow chart has SAT instead of SRT.
 						// I think that is a typographical error.
 
-	float t1v;				// How long to wait for an acknowlegement before resending.
+	float t1v;				// How long to wait for an acknowledgement before resending.
 						// Value used when starting timer T1, in seconds.
 						// "FRACK" parameter in some implementations.
 						// Typically it might be 3 seconds after frame has been
@@ -6049,7 +6049,7 @@ static void check_need_for_response (ax25_dlsm_t *S, ax25_frame_type_t frame_typ
  *
  * Outputs:	S->srt			New smoothed roundtrip time.
  *
- *		S->t1v			How long to wait for an acknowlegement before resending.
+ *		S->t1v			How long to wait for an acknowledgement before resending.
  *					Value used when starting timer T1, in seconds.
  *					Here it is dynamically adjusted.
  *

--- a/src/config.c
+++ b/src/config.c
@@ -5829,7 +5829,7 @@ static int beacon_options(char *cmd, struct beacon_s *b, int line, struct audio_
 /*
  * Process symbol now that we have any later overlay.
  *
- * FIXME: Someone who used this was surprized to end up with Solar Powser  (S-).
+ * FIXME: Someone who used this was surprised to end up with Solar Powser  (S-).
  *	overlay=S symbol="/-"
  * We should complain if overlay used with symtab other than \.
  */

--- a/src/decode_aprs.c
+++ b/src/decode_aprs.c
@@ -1375,7 +1375,7 @@ static void aprs_mic_e (decode_aprs_t *A, packet_t pp, unsigned char *info, int 
 	  }
 	}
 
-/* 6th character of destintation indicates east / west. */
+/* 6th character of destination indicates east / west. */
 
 /*
  * Example of apparently invalid encoding.  6th character missing.
@@ -1579,7 +1579,7 @@ static void aprs_mic_e (decode_aprs_t *A, packet_t pp, unsigned char *info, int 
  * Purpose:	Decode "Message Format."
  *		The word message is used loosely all over the place, but it has a very specific meaning here.
  *
- * Inputs:	info 	- Pointer to Information field.  Be carefull not to modify it here!
+ * Inputs:	info 	- Pointer to Information field.  Be careful not to modify it here!
  *		ilen 	- Information field length.
  *		quiet	- suppress error messages.
  *

--- a/src/demod.c
+++ b/src/demod.c
@@ -832,7 +832,7 @@ int demod_init (struct audio_s *pa)
  *
  * Name:        demod_get_sample
  *
- * Purpose:     Get one audio sample fromt the specified sound input source.
+ * Purpose:     Get one audio sample from the specified sound input source.
  *
  * Inputs:	a	- Index for audio device.  0 = first.
  *

--- a/src/fsk_demod_state.h
+++ b/src/fsk_demod_state.h
@@ -367,7 +367,7 @@ struct demodulator_state_s
 		// Add a sample to the total when putting it in our array of recent samples.
 		// Subtract it from the total when it gets pushed off the end.
 		// We can also eliminate the need to shift them all down by using a circular buffer.
-		// This only works with integers because float would have cummulated round off errors.
+		// This only works with integers because float would have cumulated round off errors.
 
 		cic_t cic_center1;
 		cic_t cic_above;

--- a/src/igate.c
+++ b/src/igate.c
@@ -328,7 +328,7 @@ static int stats_uplink_packets;	/* Number of packets passed along to the IGate 
 					/* server after filtering. */
 
 static int stats_uplink_bytes;		/* Total number of bytes sent to IGate server */
-					/* including login, packets, and hearbeats. */
+					/* including login, packets, and heartbeats. */
 
 static int stats_downlink_bytes;	/* Total number of bytes from IGate server including */
 					/* packets, heartbeats, other messages. */
@@ -1221,7 +1221,7 @@ static void send_packet_to_server (packet_t pp, int chan)
  * Name:        send_msg_to_server
  *
  * Purpose:     Send something to the IGate server.
- *		This one function should be used for login, hearbeats,
+ *		This one function should be used for login, heartbeats,
  *		and packets.
  *
  * Inputs:	imsg	- Message.  We will add CR/LF here.

--- a/src/il2p_header.c
+++ b/src/il2p_header.c
@@ -437,7 +437,7 @@ packet_t il2p_decode_header_type_1 (unsigned char *hdr, int num_sym_changed)
 // However, I have seen cases, where the error rate is very high, where the RS decoder
 // thinks it found a valid code block by changing one symbol but it was the wrong one.
 // The result is trash.  This shows up as address fields like 'R&G4"A' and 'TEW\ !'.
-// I added a sanity check here to catch characters other than uppper case letters and digits.
+// I added a sanity check here to catch characters other than upper case letters and digits.
 // The frame should be rejected in this case.  The question is whether to discard it
 // silently or print a message so the user can see that something strange is happening?
 // My current thinking is that it should be silently ignored if the header has been

--- a/src/il2p_payload.c
+++ b/src/il2p_payload.c
@@ -194,7 +194,7 @@ int il2p_encode_payload (unsigned char *payload, int payload_size, int max_fec, 
  * Purpose:	Extract original data from encoded payload.
  *
  * Inputs:	received	Array of bytes.  Size is unknown but in practice it
- *				must not exceeed IL2P_MAX_ENCODED_SIZE.
+ *				must not exceed IL2P_MAX_ENCODED_SIZE.
  *		payload_size	0 to 1023.  (IL2P_MAX_PAYLOAD_SIZE)
  *				Expected result size based on header.
  *		max_fec		true for 16 parity symbols, false for automatic.

--- a/src/server.c
+++ b/src/server.c
@@ -1421,7 +1421,7 @@ static THREAD_F cmd_listen_thread (void *arg)
 	}
 
 /*
- * Call to/from fields are 10 bytes but contents must not exceeed 9 characters.
+ * Call to/from fields are 10 bytes but contents must not exceed 9 characters.
  * It's not guaranteed that unused bytes will contain 0 so we
  * don't issue error message in this case. 
  */

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -681,7 +681,7 @@ void symbols_from_dest_or_src (char dti, char *src, char *dest, char *symtab, ch
 
 // The position and object formats all contain a proper symbol and table.
 // There doesn't seem to be much reason to have a symbol for something without
-// a postion because it would not show up on a map.
+// a position because it would not show up on a map.
 // This just seems to be a remnant of something used long ago and no longer needed.
 // The protocol spec mentions a "MIM tracker" but I can't find any references to it.
 

--- a/src/tt_user.c
+++ b/src/tt_user.c
@@ -882,7 +882,7 @@ static void xmit_object_report (int i, int first_time)
  * 	IGate.
  *
  * When transmitting over the radio, it gets sent multiple times, to help
- * probablity of being heard, with increasing delays between.
+ * probability of being heard, with increasing delays between.
  *
  * The other methods are reliable so we only want to send it once.
  */

--- a/src/waypoint.c
+++ b/src/waypoint.c
@@ -298,7 +298,7 @@ void waypoint_send_sentence (char *name_in, double dlat, double dlong, char symt
 	dw_printf ("waypoint_send_sentence (\"%s\", \"%c%c\")\n", name_in, symtab, symbol);
 #endif
 
-// Don't waste time if no destintations specified.
+// Don't waste time if no destinations specified.
 
 	if (s_waypoint_serial_port_fd == MYFDERROR &&
 	    s_waypoint_udp_sock_fd == -1) {

--- a/src/xmit.c
+++ b/src/xmit.c
@@ -600,7 +600,7 @@ static void * xmit_thread (void *arg)
 					// I don't know if this in some official specification
 					// somewhere, but it is generally agreed that APRS digipeaters
 					// should send only one frame at a time rather than
-					// bunding multiple frames into a single transmission.
+					// bundling multiple frames into a single transmission.
 					// Discussion here:  http://lists.tapr.org/pipermail/aprssig_lists.tapr.org/2021-September/049034.html
 	            break;
 


### PR DESCRIPTION
This PR fixes some small spelling errors.

Fixed with:
perl -pe "s/Descripion/Description/" -i src/demod*.c
codespell -w src/symbols.c