### PR TITLE
Warn about Pipewire's suspension of sinks might cause troubles

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,73 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ dev ]
+  schedule:
+    - cron: '25 8 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    - run: |
+       mkdir build
+       cd build
+       cmake -DUNITTEST=1 ..
+       make
+       make test
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/src/xmit.c
+++ b/src/xmit.c
@@ -913,9 +913,19 @@ static void xmit_ax25_frames (int chan, int prio, packet_t pp, int max_bundle)
 
 	  /* Looks like a bug with the RPi audio system. Never an issue with Ubuntu.  */
 	  /* This runs over randomly sometimes. TODO:  investigate more fully sometime. */
+
 #ifndef __arm__
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Transmit timing error: PTT is on %d mSec too long.\n", -wait_more);
+
+	  /* This also happens with recent Linux distributions with PipeWire audio subsystem */
+	  /* where Wireplumber in its default setting turns off the audio output sink after */
+	  /* several seconds of inactivity, which results in slight delay while warming up again. */
+	  /* See: https://unix.stackexchange.com/questions/676846/how-do-i-disable-audio-sink-suspend-on-idle-using-wireplumber-in-fedora-35-so-th */
+#if USE_ALSA
+	  dw_printf ("If using PipeWIre, make sure your output sinks are not being suspended for inactivity.\n");
+#endif
+
 #endif
 	}
 


### PR DESCRIPTION
When using Direwolf with recent Linux distributions on amd64 and Pi with PipeWire audio subsystem with Wireplumber in its default settings, audio output sinks are being suspended after several seconds of inactivity, which results in slight delay while warming up again. This results in spitting `Transmit timing error: PTT is on XXXXX mSec too long` error message which is not very helpful. This pull request adds few more hints when running via ALSA subsystem.