### PR TITLE
bump up GPSD_API_MAJOR_VERSION 12 (gpsd-3.23)

### DIFF
--- a/src/dwgpsd.c
+++ b/src/dwgpsd.c
@@ -60,7 +60,7 @@
 // An incompatibility was introduced with version 7
 // and again with 9 and again with 10.
 
-#if GPSD_API_MAJOR_VERSION < 5 || GPSD_API_MAJOR_VERSION > 11
+#if GPSD_API_MAJOR_VERSION < 5 || GPSD_API_MAJOR_VERSION > 12
 #error libgps API version might be incompatible.
 #endif
 


### PR DESCRIPTION
OpenBSD's ports (binary package) has gpsd-3.23.1 and its API version is 12.
dwgpsd supports API version between 5 and 11, it fits gpsd-3.0(API v5) to gpsd-3.21 (API v10).

This PR cannot support latest gpsd relase-3.24 (API v14), please fix if anyone can test with latest libgps.