### PR TITLE
Add in a couple missing includes to clean up build warnings

### DIFF
--- a/src/atest.c
+++ b/src/atest.c
@@ -68,6 +68,7 @@
 #include <string.h>
 #include <time.h>
 #include <getopt.h>
+#include <ctype.h>
 
 
 #define ATEST_C 1

--- a/src/kissutil.c
+++ b/src/kissutil.c
@@ -68,6 +68,7 @@
 #include "kiss_frame.h"
 #include "dwsock.h"
 #include "audio.h"		// for DEFAULT_TXDELAY, etc.
+#include "dtime_now.h"
 
 
 // TODO:  define in one place, use everywhere.


### PR DESCRIPTION
Clean up a couple implicit declaration warnings seen on Raspian bullseye.