### PR TITLE
Add agc_fast_attack and agc_slow_decay into B/D afsk demod init

### DIFF
--- a/src/demod_afsk.c
+++ b/src/demod_afsk.c
@@ -309,10 +309,6 @@ void demod_afsk_init (int samples_per_sec, int baud, int mark_freq,
 	      D->lp_window = BP_WINDOW_TRUNCATED;
 	    }
 
-	    D->agc_fast_attack = 0.820;		
-	    D->agc_slow_decay = 0.000214;
-	    D->agc_fast_attack = 0.45;		
-	    D->agc_slow_decay = 0.000195;
 	    D->agc_fast_attack = 0.70;		
 	    D->agc_slow_decay = 0.000090;
 
@@ -371,6 +367,9 @@ void demod_afsk_init (int samples_per_sec, int baud, int mark_freq,
 
 	    // For scaling phase shift into normallized -1 to +1 range for mark and space.
 	    D->u.afsk.normalize_rpsam = 1.0 / (0.5 * abs(mark_freq - space_freq) * 2 * M_PI / samples_per_sec);
+
+	    D->agc_fast_attack = 0.70;
+	    D->agc_slow_decay = 0.000090;
 
 	    D->pll_locked_inertia = 0.74;
 	    D->pll_searching_inertia = 0.50;


### PR DESCRIPTION
The agc_fast_attack and agc_slow_decay fields were initialized to 0 in the B/D demodulator. As a result, the level calculations would always come out to 0 resulting in the following...

Jan 04 08:13:25 direwolf[614]: ADEVICE0: Sample rate approx. 44.1 k, 0 errors, receive audio level CH0 0
Jan 04 08:14:33 direwolf[614]: AB4KR-1 audio level = 0(-99/-99)   [NONE]   _____||_
Jan 04 08:14:33 direwolf[614]: Audio input level is too low.  Increase so most stations are around 50.

Set the values to the same as A/E demodulator.

Also cleaned up some duplicate assignments in A/E demodulator
