### PR TITLE
Fix compiling optional tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -646,6 +646,27 @@ if(OPTIONAL_TEST)
     ${CUSTOM_SRC_DIR}/audio_stats.c
     ${CUSTOM_SRC_DIR}/dtime_now.c
     ${CUSTOM_SRC_DIR}/dlq.c
+    ${CUSTOM_SRC_DIR}/ax25_pad2.c
+    ${CUSTOM_SRC_DIR}/decode_aprs.c
+    ${CUSTOM_SRC_DIR}/fx25_encode.c
+    ${CUSTOM_SRC_DIR}/fx25_extract.c
+    ${CUSTOM_SRC_DIR}/fx25_init.c
+    ${CUSTOM_SRC_DIR}/fx25_rec.c
+    ${CUSTOM_SRC_DIR}/fx25_send.c
+    ${CUSTOM_SRC_DIR}/gen_tone.c
+    ${CUSTOM_SRC_DIR}/igate.c
+    ${CUSTOM_SRC_DIR}/il2p_codec.c
+    ${CUSTOM_SRC_DIR}/il2p_header.c
+    ${CUSTOM_SRC_DIR}/il2p_init.c
+    ${CUSTOM_SRC_DIR}/il2p_payload.c
+    ${CUSTOM_SRC_DIR}/il2p_rec.c
+    ${CUSTOM_SRC_DIR}/il2p_scramble.c
+    ${CUSTOM_SRC_DIR}/il2p_send.c
+    ${CUSTOM_SRC_DIR}/mheard.c
+    ${CUSTOM_SRC_DIR}/pfilter.c
+    ${CUSTOM_SRC_DIR}/symbols.c
+    ${CUSTOM_SRC_DIR}/telemetry.c
+    ${CUSTOM_SRC_DIR}/tt_text.c
     )
 
   if(LINUX)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -577,6 +577,17 @@ if(OPTIONAL_TEST)
     ${CUSTOM_SRC_DIR}/tt_text.c
     ${CUSTOM_SRC_DIR}/symbols.c
     ${CUSTOM_SRC_DIR}/textcolor.c
+    ${CUSTOM_SRC_DIR}/ax25_pad2.c
+    ${CUSTOM_SRC_DIR}/fx25_init.c
+    ${CUSTOM_SRC_DIR}/fx25_encode.c
+    ${CUSTOM_SRC_DIR}/fx25_extract.c
+    ${CUSTOM_SRC_DIR}/fx25_rec.c
+    ${CUSTOM_SRC_DIR}/il2p_header.c
+    ${CUSTOM_SRC_DIR}/il2p_init.c
+    ${CUSTOM_SRC_DIR}/il2p_codec.c
+    ${CUSTOM_SRC_DIR}/il2p_payload.c
+    ${CUSTOM_SRC_DIR}/il2p_rec.c
+    ${CUSTOM_SRC_DIR}/il2p_scramble.c
     )
 
   if(WIN32 OR CYGWIN)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -523,6 +523,7 @@ if(OPTIONAL_TEST)
     ${CUSTOM_SRC_DIR}/latlong.c
     ${CUSTOM_SRC_DIR}/tt_text.c
     ${CUSTOM_SRC_DIR}/symbols.c
+    ${CUSTOM_SRC_DIR}/dlq.c
     )
 
   if(WIN32 OR CYGWIN)


### PR DESCRIPTION
This PR fixes compiling `itest`, `trestagc`, and `walk96` enabled when running `cmake -DOPTIONAL_TEST=ON ..`
