### PR TITLE
Fix make package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ else()
     set(INSTALL_MAN_DIR "share/man/man1")
   endif()
   set(INSTALL_DATA_DIR "share/${PROJECT_NAME}")
+  set(INSTALL_UDEV_DIR "etc/udev/rules.d/")
 endif(WIN32 OR CYGWIN)
 
 # requirements

--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -26,7 +26,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/direwolf.conf" "${file_content}")
 
 # install udev rules for CM108
 if(LINUX)
-  install(FILES "${CUSTOM_CONF_DIR}/99-direwolf-cmedia.rules" DESTINATION /etc/udev/rules.d/)
+  install(FILES "${CUSTOM_CONF_DIR}/99-direwolf-cmedia.rules" DESTINATION ${INSTALL_UDEV_DIR})
 endif()
 
 install(FILES "${CMAKE_BINARY_DIR}/direwolf.conf" DESTINATION ${INSTALL_CONF_DIR})


### PR DESCRIPTION
This PR allows the execution of `make package` as an ordinary user and prevents the overwriting of a system file.
