### PR TITLE
Remove stray comma

### DIFF
--- a/src/gen_tone.c
+++ b/src/gen_tone.c
@@ -577,7 +577,7 @@ int main ()
 
 	memset (&my_audio_config, 0, sizeof(my_audio_config));
 	strlcpy (my_audio_config.adev[0].adevice_in, DEFAULT_ADEVICE, sizeof(my_audio_config.adev[0].adevice_in));
-	strlcpy (my_audio_config.adev[0].adevice_out, DEFAULT_ADEVICE, , sizeof(my_audio_config.adev[0].adevice_out));
+	strlcpy (my_audio_config.adev[0].adevice_out, DEFAULT_ADEVICE, sizeof(my_audio_config.adev[0].adevice_out));
 	my_audio_config.adev[0].num_channels = 2;
 
 	audio_open (&my_audio_config);


### PR DESCRIPTION
Fixes cppcheck error:
src/gen_tone.c:580:0: error: failed to expand 'strlcpy', Wrong number of parameters for macro 'strlcpy'. [preprocessorErrorDirective]
 strlcpy (my_audio_config.adev[0].adevice_out, DEFAULT_ADEVICE, , sizeof(my_audio_config.adev[0].adevice_out));
^