### PR TITLE
Add support for full CTCSS and DCS beacon options

### DIFF
--- a/src/beacon.c
+++ b/src/beacon.c
@@ -893,7 +893,7 @@ static void beacon_send (int j, dwgps_info_t *gpsinfo)
 			bp->symtab, bp->symbol,
 			bp->power, bp->height, bp->gain, bp->dir,
 			G_UNKNOWN, G_UNKNOWN, /* course, speed */
-			bp->freq, bp->tone, bp->offset,
+			bp->freq, bp->tone_type, bp->tone, bp->offset,
 			super_comment,
 			info, sizeof(info));
 		  strlcat (beacon_text, info, sizeof(beacon_text));
@@ -905,7 +905,7 @@ static void beacon_send (int j, dwgps_info_t *gpsinfo)
 			bp->symtab, bp->symbol,
 			bp->power, bp->height, bp->gain, bp->dir,
 			G_UNKNOWN, G_UNKNOWN, /* course, speed */
-			bp->freq, bp->tone, bp->offset, super_comment,
+			bp->freq, bp-> tone_type, bp->tone, bp->offset, super_comment,
 			info, sizeof(info));
 		  strlcat (beacon_text, info, sizeof(beacon_text));
 		  break;
@@ -936,7 +936,7 @@ static void beacon_send (int j, dwgps_info_t *gpsinfo)
 			bp->symtab, bp->symbol,
 			bp->power, bp->height, bp->gain, bp->dir,
 			coarse, (int)roundf(gpsinfo->speed_knots),
-			bp->freq, bp->tone, bp->offset,
+			bp->freq, bp->tone_type, bp->tone, bp->offset,
 			super_comment,
 			info, sizeof(info));
 		    strlcat (beacon_text, info, sizeof(beacon_text));

--- a/src/config.c
+++ b/src/config.c
@@ -6020,6 +6020,7 @@ static int beacon_options(char *cmd, struct beacon_s *b, int line, struct audio_
 	b->symtab = '/';
 	b->symbol = '-';	/* house */
 	b->freq = G_UNKNOWN;
+	b->tone_type = 'T';
 	b->tone = G_UNKNOWN;
 	b->offset = G_UNKNOWN;
 	b->source = NULL;
@@ -6270,7 +6271,33 @@ static int beacon_options(char *cmd, struct beacon_s *b, int line, struct audio_
 	    b->freq = atof(value);
 	  }
 	  else if (strcasecmp(keyword, "TONE") == 0) {
-	    b->tone = atof(value);
+	    int n = 0;
+	    char type = '\0';
+	    float tone = 0;
+
+	    b->tone_type = 'T';
+	    b->tone = 0;
+
+	    /* Legacy format: plain numeric tone value, including 0 for tone-off. */
+	    if (sscanf(value, " %f %n", &tone, &n) == 1 && value[n] == '\0') {
+	      b->tone = tone;
+	    }
+	    /* Extended format: type prefix plus value (T/C/D), e.g. C100 or D023. */
+	    else if (sscanf(value, " %c%f %n", &type, &tone, &n) == 2 && value[n] == '\0') {
+	      type = toupper((unsigned char)type);
+	      if (type == 'T' || type == 'C' || type == 'D') {
+	        b->tone_type = type;
+	        b->tone = tone;
+	      }
+	      else {
+	        text_color_set(DW_COLOR_ERROR);
+	        dw_printf ("Config file, line %d: Bad tone type, %c.  Use T, C, or D.\n", line, type);
+	      }
+	    }
+	    else {
+	      text_color_set(DW_COLOR_ERROR);
+	      dw_printf ("Config file, line %d: Bad tone format, %s.\n", line, value);
+	    }
 	  }
 	  else if (strcasecmp(keyword, "OFFSET") == 0 || strcasecmp(keyword, "OFF") == 0) {
 	    b->offset = atof(value);

--- a/src/config.h
+++ b/src/config.h
@@ -233,6 +233,7 @@ struct misc_config_s {
 	  char dir[3];		/* 1 or 2 of N,E,W,S, or empty for omni. */
 
 	  float freq;		/* MHz. */
+	  char  tone_type;	/* Tone(T), Tone Squelch(C) or DCS(D) */
 	  float tone;		/* Hz. */
 	  float offset;		/* MHz. */
 	

--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -1591,7 +1591,7 @@ void app_process_rec_packet (int chan, int subchan, int slice, packet_t pp, alev
 	        // Unknown not handled properly.
 		// Should encode_object take floating point here?
 		(int)(A.g_course+0.5), (int)(DW_MPH_TO_KNOTS(A.g_speed_mph)+0.5),
-		0, 0, 0, A.g_comment,	// freq, tone, offset
+		0, 'T', 0, 0, A.g_comment,	// freq, tone_type, tone, offset
 		ais_obj_info, sizeof(ais_obj_info));
 
 	      snprintf (ais_obj_packet, sizeof(ais_obj_packet), "%s>%s%1d%1d,NOGATE:%s", A.g_src, APP_TOCALL, MAJOR_VERSION, MINOR_VERSION, ais_obj_info);

--- a/src/encode_aprs.c
+++ b/src/encode_aprs.c
@@ -405,6 +405,7 @@ static int cse_spd_data_extension (int course, int speed, char *presult)
  * Purpose:     Put frequency specification in beginning of comment field.
  *
  * Inputs: 	freq	- MHz.
+ *		tone_type - T/Tone, C/Tone Squelch, D/DCS
  *		tone	- Hz.
  *		offset	- MHz.
  *
@@ -430,7 +431,7 @@ static int cse_spd_data_extension (int course, int speed, char *presult)
  *----------------------------------------------------------------*/
 
 
-static int frequency_spec (float freq, float tone, float offset, char *presult)
+static int frequency_spec (float freq, char tone_type, float tone, float offset, char *presult)
 {
 	int result_size = 24;		// TODO: add as parameter.
 
@@ -452,14 +453,27 @@ static int frequency_spec (float freq, float tone, float offset, char *presult)
 	if (tone != G_UNKNOWN) {
 	  char stemp[12];
 
+	  stemp[0] = '\0';
+
 	  if (tone == 0) {
 	    strlcpy (stemp, "Toff ", sizeof (stemp));
 	  }
 	  else {
-	    snprintf (stemp, sizeof(stemp), "T%03d ", (int)tone);
+	    /* Tone enabled */
+	    if (tone_type == 'T' || tone_type == 'C' || tone_type == 'D') {
+	      /* CTCSS Tone or DCS Code*/
+	      snprintf(stemp, sizeof(stemp), "%c%03d ", tone_type, (int)tone);
+	    } else {
+	      /* Error */
+	      text_color_set(DW_COLOR_ERROR);
+	      dw_printf("Invalid tone type, %c.  Using T.\n", tone_type);
+	      snprintf(stemp, sizeof(stemp), "T%03d ", (int)tone);
+	    }
 	  }
 
-	  strlcat (presult, stemp, result_size);
+	  if (stemp[0] != '\0') {
+	    strlcat (presult, stemp, result_size);
+	  }
 	}
 
 	if (offset != G_UNKNOWN) {
@@ -499,6 +513,7 @@ static int frequency_spec (float freq, float tone, float offset, char *presult)
  *		speed	- knots.		// TODO:  should distinguish unknown(not revevant) vs. known zero.
  *
  * 	 	freq	- MHz.
+ * 	 	tone_type - T/C/D
  *		tone	- Hz.
  *		offset	- MHz.
  *
@@ -544,7 +559,7 @@ int encode_position (int messaging, int compressed, double lat, double lon, int 
 		char symtab, char symbol, 
 		int power, int height, int gain, char *dir,
 		int course, int speed,
-		float freq, float tone, float offset,
+		float freq, char tone_type, float tone, float offset,
 		char *comment,
 		char *presult, size_t result_size)
 {
@@ -590,7 +605,7 @@ int encode_position (int messaging, int compressed, double lat, double lon, int 
 /* Optional frequency spec. */
 
 	if (freq != 0 || tone != 0 || offset != 0) {
-	  result_len += frequency_spec (freq, tone, offset, presult + result_len);
+	  result_len += frequency_spec (freq, tone_type, tone, offset, presult + result_len);
 	}
 
 	presult[result_len] = '\0';
@@ -658,6 +673,7 @@ int encode_position (int messaging, int compressed, double lat, double lon, int 
  *		speed	- knots.
  *
  * 	 	freq	- MHz.
+ * 	 	tone_type - T/C/D 
  *		tone	- Hz.
  *		offset	- MHz.
  *
@@ -695,7 +711,7 @@ int encode_object (char *name, int compressed, time_t thyme, double lat, double 
 		char symtab, char symbol, 
 		int power, int height, int gain, char *dir,
 		int course, int speed,
-		float freq, float tone, float offset, char *comment,
+		float freq, char tone_type, float tone, float offset, char *comment,
 		char *presult, size_t result_size)
 {
 	aprs_object_t *p = (aprs_object_t *) presult;
@@ -761,7 +777,7 @@ int encode_object (char *name, int compressed, time_t thyme, double lat, double 
 /* Optional frequency spec. */
 
 	if (freq != 0 || tone != 0 || offset != 0) {
-	  result_len += frequency_spec (freq, tone, offset, presult + result_len);
+	  result_len += frequency_spec (freq, tone_type, tone, offset, presult + result_len);
 	}
 
 	presult[result_len] = '\0';
@@ -865,7 +881,7 @@ int main (int argc, char *argv[])
 /***********  Position  ***********/
 
 	encode_position (0, 0, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		0, 0, 0, NULL, G_UNKNOWN, 0, 0, 0, 0, NULL, result, sizeof(result));
+		0, 0, 0, NULL, G_UNKNOWN, 0, 0, 'T', 0, 0, NULL, result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!4234.61ND07126.47W&") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
@@ -873,50 +889,50 @@ int main (int argc, char *argv[])
 // TODO:  Need to test specifying some but not all.
 
 	encode_position (0, 0, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		50, 100, 6, "N", G_UNKNOWN, 0, 0, 0, 0, NULL, result, sizeof(result));
+		50, 100, 6, "N", G_UNKNOWN, 0, 0, 'T', 0, 0, NULL, result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!4234.61ND07126.47W&PHG7368") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
 /* with freq & tone.  minus offset, no offset, explicit simplex. */
 
 	encode_position (0, 0, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		0, 0, 0, NULL, G_UNKNOWN, 0, 146.955, 74.4, -0.6, NULL, result, sizeof(result));
+		0, 0, 0, NULL, G_UNKNOWN, 0, 146.955, 'T', 74.4, -0.6, NULL, result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!4234.61ND07126.47W&146.955MHz T074 -060 ") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
 	encode_position (0, 0, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		0, 0, 0, NULL, G_UNKNOWN, 0, 146.955, 74.4, G_UNKNOWN, NULL, result, sizeof(result));
+		0, 0, 0, NULL, G_UNKNOWN, 0, 146.955, 'T', 74.4, G_UNKNOWN, NULL, result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!4234.61ND07126.47W&146.955MHz T074 ") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
 	encode_position (0, 0, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		0, 0, 0, NULL, G_UNKNOWN, 0, 146.955, 74.4, 0, NULL, result, sizeof(result));
+		0, 0, 0, NULL, G_UNKNOWN, 0, 146.955, 'T', 74.4, 0, NULL, result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!4234.61ND07126.47W&146.955MHz T074 +000 ") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
 /* with course/speed, freq, and comment! */
 
 	encode_position (0, 0, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		0, 0, 0, NULL, 180, 55, 146.955, 74.4, -0.6, "River flooding", result, sizeof(result));
+		0, 0, 0, NULL, 180, 55, 146.955, 'T', 74.4, -0.6, "River flooding", result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!4234.61ND07126.47W&180/055146.955MHz T074 -060 River flooding") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
 /* Course speed, no tone, + offset */
 
 	encode_position (0, 0, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		0, 0, 0, NULL, 180, 55, 146.955, G_UNKNOWN, 0.6, "River flooding", result, sizeof(result));
+		0, 0, 0, NULL, 180, 55, 146.955, 'T', G_UNKNOWN, 0.6, "River flooding", result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!4234.61ND07126.47W&180/055146.955MHz +060 River flooding") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
 /* Course speed, no tone, + offset + altitude */
 
 	encode_position (0, 0, 42+34.61/60, -(71+26.47/60), 0, 12345, 'D', '&',
-		0, 0, 0, NULL, 180, 55, 146.955, G_UNKNOWN, 0.6, "River flooding", result, sizeof(result));
+		0, 0, 0, NULL, 180, 55, 146.955, 'T', G_UNKNOWN, 0.6, "River flooding", result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!4234.61ND07126.47W&180/055146.955MHz +060 /A=012345River flooding") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
 	encode_position (0, 0, 42+34.61/60, -(71+26.47/60), 0, 12345, 'D', '&',
-		0, 0, 0, NULL, 180, 55, 146.955, 0, 0.6, "River flooding", result, sizeof(result));
+		0, 0, 0, NULL, 180, 55, 146.955, 'T', 0, 0.6, "River flooding", result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!4234.61ND07126.47W&180/055146.955MHz Toff +060 /A=012345River flooding") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
@@ -925,7 +941,7 @@ int main (int argc, char *argv[])
 /*********** Compressed position. ***********/
 
 	encode_position (0, 1, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		0, 0, 0, NULL, G_UNKNOWN, 0, 0, 0, 0, NULL, result, sizeof(result));
+		0, 0, 0, NULL, G_UNKNOWN, 0, 0, 'T', 0, 0, NULL, result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!D8yKC<Hn[&  !") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
@@ -933,14 +949,14 @@ int main (int argc, char *argv[])
 /* with PHG. In this case it is converted to precomputed radio range.  TODO: check on this.  Is 27.4 correct? */
 
 	encode_position (0, 1, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		50, 100, 6, "N", G_UNKNOWN, 0, 0, 0, 0, NULL, result, sizeof(result));
+		50, 100, 6, "N", G_UNKNOWN, 0, 0, 'T', 0, 0, NULL, result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!D8yKC<Hn[&{CG") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
 /* with course/speed, freq, and comment!  Roundoff. 55 knots should be 63 MPH.  we get 62. */
 
 	encode_position (0, 1, 42+34.61/60, -(71+26.47/60), 0, G_UNKNOWN, 'D', '&',
-		0, 0, 0, NULL, 180, 55, 146.955, 74.4, -0.6, "River flooding", result, sizeof(result));
+		0, 0, 0, NULL, 180, 55, 146.955, 'T', 74.4, -0.6, "River flooding", result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, "!D8yKC<Hn[&NUG146.955MHz T074 -060 River flooding") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 
@@ -950,7 +966,7 @@ int main (int argc, char *argv[])
 /*********** Object. ***********/
 
 	encode_object ("WB1GOF-C", 0, 0, 42+34.61/60, -(71+26.47/60), 0, 'D', '&',
-		0, 0, 0, NULL, G_UNKNOWN, 0, 0, 0, 0, NULL, result, sizeof(result));
+		0, 0, 0, NULL, G_UNKNOWN, 0, 0, 'T', 0, 0, NULL, result, sizeof(result));
 	dw_printf ("%s\n", result);
 	if (strcmp(result, ";WB1GOF-C *111111z4234.61ND07126.47W&") != 0) { dw_printf ("ERROR!  line %d\n", __LINE__); errors++; }
 

--- a/src/encode_aprs.h
+++ b/src/encode_aprs.h
@@ -3,7 +3,7 @@ int encode_position (int messaging, int compressed, double lat, double lon, int 
 		char symtab, char symbol, 
 		int power, int height, int gain, char *dir,
 		int course, int speed_knots,
-		float freq, float tone, float offset,
+		float freq, char tone_type, float tone, float offset,
 		char *comment,
 		char *presult, size_t result_size);
 
@@ -11,7 +11,7 @@ int encode_object (char *name, int compressed, time_t thyme, double lat, double 
 		char symtab, char symbol, 
 		int power, int height, int gain, char *dir,
 		int course, int speed_knots,
-		float freq, float tone, float offset, char *comment,
+		float freq, char tone_type, float tone, float offset, char *comment,
 		char *presult, size_t result_size);
 
 int encode_message (char *addressee, char *text, char *id, char *presult, size_t result_size);

--- a/src/tt_user.c
+++ b/src/tt_user.c
@@ -846,6 +846,7 @@ static void xmit_object_report (int i, int first_time)
 		tt_user[i].overlay, tt_user[i].symbol, 
 		0,0,0,NULL, G_UNKNOWN, G_UNKNOWN,	/* PHGD, Course/Speed */
 		strlen(tt_user[i].freq) > 0 ? atof(tt_user[i].freq) : G_UNKNOWN,
+		'T',
 		strlen(tt_user[i].ctcss) > 0 ? atof(tt_user[i].ctcss) : G_UNKNOWN,
 		G_UNKNOWN,	/* CTCSS */
 		info_comment, object_info, sizeof(object_info));

--- a/src/walk96.c
+++ b/src/walk96.c
@@ -156,7 +156,7 @@ static void walk96 (int fix, double lat, double lon, float knots, float course, 
 		'/', '=',
 		G_UNKNOWN, G_UNKNOWN, G_UNKNOWN, "",	// PHGd
 		(int)roundf(course), (int)roundf(knots),
-		445.925, 0, 0,
+		445.925, 'T', 0, 0,
 		comment,
 		info, sizeof(info));
 


### PR DESCRIPTION
This change adds the ability to include the tone type specifier to a beacon's frequency info. Today a beacon can include the T{number} field to specify a tone. The APRS spec includes support for CTCSS tone squelch and DCS codes. 
http://www.aprs.org/info/freqspec.txt
With this change the tone argument can be set to a value of the form specified in the spec. For example, specifying a CTCSS squelch of 107.3, the TONE argument can be set to C107, or if a DCS code of 047 is to be specified the TONE value can be set to D047.
If the TONE argument in a beacon line is set to just a numeric value, it will assume this is specifying a tone specifier as it always has and will add a leading T to the value specified.

I looked at the decoding path and it appears that the the beacon decode path already understands the different tone leading characters.

This change would imply a documentation change to add these options to the TONE argument in beacon lines.