### PR TITLE
Fix cmake error on external misc library

### DIFF
--- a/external/misc/CMakeLists.txt
+++ b/external/misc/CMakeLists.txt
@@ -32,9 +32,14 @@ if(LINUX)
       )
   endif()
 
-  add_library(misc STATIC
-    ${misc_SOURCES}
-    )
+  if ( "${misc_SOURCES}" )
+    add_library(misc STATIC
+      ${misc_SOURCES}
+      )
+  else()
+    # Nothing to build
+    set(MISC_LIBRARIES "" CACHE INTERNAL "")
+  endif()
 
 elseif(WIN32 OR CYGWIN) # windows
 


### PR DESCRIPTION
For Linux builds, if strlcpt and strlcat are already provided, cmake is given an empty list of sources to build for the "misc" library. Newer versions of cmake throw an error for this. In this case, we should just avoid building the library.

Failure pattern:
CMake Error at external/misc/CMakeLists.txt:35 (add_library):
  No SOURCES given to target: misc
CMake Generate step failed.  Build files cannot be regenerated correctly.

Fixes #319