### PR TITLE
Update deprecated CMake command `exec_program()`

### DIFF
--- a/cmake/include/uninstall.cmake.in
+++ b/cmake/include/uninstall.cmake.in
@@ -7,10 +7,10 @@ string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
   if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-    exec_program(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+    execute_process(
+      COMMAND "@CMAKE_COMMAND@" -E remove "$ENV{DESTDIR}${file}"
       OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
+      RESULT_VARIABLE rm_retval
       )
     if(NOT "${rm_retval}" STREQUAL 0)
       message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")


### PR DESCRIPTION
Per the cmake documentation:

  > *Changed in version 3.28:* This command is available only if policy CMP0153
  >   is not set to NEW. Port projects to the execute_process() command.
  >
  > *Deprecated since version 3.0:* Use the execute_process() command instead.

To avoid warnings or future errors, calls to `exec_program()` have been replaced with the recommended `execute_process()` command.