### PR TITLE
Update generic.conf - add directional antenna example

### DIFF
--- a/conf/generic.conf
+++ b/conf/generic.conf
@@ -433,6 +433,11 @@
 %C%#PBEACON delay=1 every=10 overlay=S symbol="digi" zone=19T easting=307477 northing=4720178
 %C%
 %C%
+%C%# Using a directional antenna pointing SW instead of omni (see http://www.aprs.org/aprsdos-pix/phg.txt and src/encode_aprs.c)
+%C%
+%C%#PBEACON delay=1 every=30 overlay=S symbol="digi" lat=42^37.14N long=071^20.83W power=50 height=20 gain=9 dir=SW comment="Chelmsford MA" via=WIDE1-1
+%C%
+%C%
 %C%#
 %C%# When the destination field is set to "SPEECH" the information part is
 %C%# converted to speech rather than transmitted as a data frame.


### PR DESCRIPTION
The manual seems to be missing this explanation, so I added an example for setting the direction of the antenna in the PBEACON