### PR TITLE
atest: Change .wav data size to be unsigned 32bit int

### DIFF
--- a/src/atest.c
+++ b/src/atest.c
@@ -134,7 +134,7 @@ static struct {
 
 static struct {
 	char data[4];		/* "data" */
-	int datasize;
+	uint32_t datasize;
 } wav_data;
 
 


### PR DESCRIPTION
This allows .wav files bigger than 2GiB.