### PR TITLE
Improve atest CLI documentation

### DIFF
--- a/man/atest.1
+++ b/man/atest.1
@@ -62,6 +62,11 @@ Force G3RUH modem regardless of data rate.
 Divide audio sample rate by n.
 
 .TP
+.BI  "-U " "n"
+Override automatic upsampling rate for G3RUH,
+improving performance when sample rate to baud ratio is low.
+
+.TP
 .BI  "-h " 
 Print frame contents as hexadecimal bytes.
 

--- a/man/atest.1
+++ b/man/atest.1
@@ -73,6 +73,10 @@ Amount of effort to try fixing frames with an invalid CRC.
 more = Try modifying more bits to get a good CRC.
 
 .TP
+.BI  "-e " "n"
+Artificially introduce a desired Bit Error Rate (BER) for testing.
+
+.TP
 .BI  "-L " 
 Error if Less than this number decoded.
 

--- a/src/atest.c
+++ b/src/atest.c
@@ -987,6 +987,8 @@ static void usage (void) {
 	dw_printf ("        -J     2400 bps QPSK compatible with MFJ-2400.\n");
 	dw_printf ("\n");
 	dw_printf ("        -D n   Divide audio sample rate by n.\n");
+	dw_printf ("        -U n   Override automatic upsampling rate for G3RUH,\n");
+	dw_printf ("               improving performance when sample rate to baud ratio is low.\n");
 	dw_printf ("\n");
 	dw_printf ("        -h     Print frame contents as hexadecimal bytes.\n");
 	dw_printf ("\n");

--- a/src/atest.c
+++ b/src/atest.c
@@ -982,7 +982,7 @@ static void usage (void) {
 	dw_printf ("               AIS for ship Automatic Identification System.\n");
 	dw_printf ("               EAS for Emergency Alert System (EAS) Specific Area Message Encoding (SAME).\n");
 	dw_printf ("\n");
-	dw_printf ("        -g     Use G3RUH modem rather rather than default for data rate.\n");
+	dw_printf ("        -g     Use G3RUH modem rather than default for data rate.\n");
 	dw_printf ("        -j     2400 bps QPSK compatible with direwolf <= 1.5.\n");
 	dw_printf ("        -J     2400 bps QPSK compatible with MFJ-2400.\n");
 	dw_printf ("\n");

--- a/src/atest.c
+++ b/src/atest.c
@@ -994,6 +994,7 @@ static void usage (void) {
 	dw_printf ("               0 (default) = consider only correct frames.  \n");
 	dw_printf ("               1 = Try to fix only a single bit.  \n");
 	dw_printf ("               more = Try modifying more bits to get a good CRC.\n");
+	dw_printf ("        -e n   Artificially introduce a desired Bit Error Rate (BER) for testing.\n");
 	dw_printf ("\n");
 	dw_printf ("        -d x   Debug information for FX.25.  Repeat for more detail.\n");
 	dw_printf ("\n");


### PR DESCRIPTION
Adds documentation for `-e` and `-U` and fixes a typo in the `-g` help message