### PR TITLE
Fix deviceid test when model present but no vendor

### DIFF
--- a/src/deviceid.c
+++ b/src/deviceid.c
@@ -551,6 +551,11 @@ void deviceid_decode_dest (char *dest, char *device, size_t device_size)
 	      strlcat (device, " ", device_size);
 	    }
 
+	    if (ptocalls[n].vendor == NULL && ptocalls[n].model != NULL) {
+	      // If we don't have a vendor, but do have a model, wipe the error message
+	      strlcpy (device, "", device_size);
+	    }
+
 	    if (ptocalls[n].model != NULL) {
 	      strlcat (device, ptocalls[n].model, device_size);
 	    }


### PR DESCRIPTION
Fixes small bug introduced in b26c5a4d7d4b2fd19160a1ff20cece13b2c18b13

Without this, the error message was appended to, and e.g. `device` could end up as "UNKNOWN vendor/modelAFilterX" instead of the expected "AFilterX"