### PR TITLE
Include limits.h for MAX_PATH

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>


### PR DESCRIPTION
ade6d0e79b6da9ac9324cd2abf06757ee3482353 included changes in config.c to use realpath(3) to determine the full path of a config file, declaring a char array of size PATH_MAX for storage - except this broke because PATH_MAX is defined in limits.h which wasn't included.