### PR TITLE
Don't announce via DNS-SD if KISS port not configured

### DIFF
--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -1137,7 +1137,7 @@ int main (int argc, char *argv[])
 	kissnet_init (&misc_config);
 
 #if (USE_AVAHI_CLIENT|USE_MACOS_DNSSD)
-	if (misc_config.kiss_port > 0 && misc_config.dns_sd_enabled)
+	if (misc_config.kiss_port[0] > 0 && misc_config.dns_sd_enabled)
 	  dns_sd_announce(&misc_config);
 #endif
 


### PR DESCRIPTION
When "KISSPORT 0" is used in the config file to remove the default port, and no other port is configured, Direwolf still announces a KISS service on port 0. This is happening because the check for a valid KISS port was not updated when 'kiss_port' was changed from a single value to an array (for support of multiple KISS ports), so the test is checking against the wrong value.

Checking against the first port in the list, per this commit, is consistent with the use of this same value for the port number that is announced via DNS-SD. When support is added for announcing multiple ports, this check should be updated to check for any valid port.

Fixes #386