### PR TITLE
Add support for Heard Stations via AGWPE

### DIFF
--- a/src/mheard.h
+++ b/src/mheard.h
@@ -5,6 +5,19 @@
 #include "decode_aprs.h"	// for decode_aprs_t
 
 
+typedef struct mheard_times_s {
+
+	char callsign[AX25_MAX_ADDR_LEN];	// Callsign from the AX.25 source field.
+
+	int chan;				// Channel with which these times are associated.
+
+    time_t first_heard;		// Timestamp when first heard on this channel.
+
+	time_t last_heard;		// Timestamp when last heard on this channel.
+
+} mheard_times_t;
+
+
 void mheard_init (int debug);
 
 void mheard_save_rf (int chan, decode_aprs_t *A, packet_t pp, alevel_t alevel, retry_t retries);
@@ -18,3 +31,7 @@ int mheard_was_recently_nearby (char *role, char *callsign, int time_limit, int 
 void mheard_set_msp (char *callsign, int num);
 
 int mheard_get_msp (char *callsign);
+
+int mheard_latest_for_channel (int chan, mheard_times_t *times, int num_times);
+
+int mheard_latest_for_is (mheard_times_t *times, int num_times);


### PR DESCRIPTION
An AGWPE client request for Heard Stations ('H' frame) requires that data for the most recent 20 heard callsigns be returned. Much of the data for this was already being collected, and displayed with the '-d m' command line option, but was not available via AGWPE.

The following changes have been made to support requests for Heard Stations:

* Last heard times are now saved on a per-channel basis, since the AGWPE request specifies the channel for which data is being requested. The most recently heard time on any channel is still available using the 'chan' value, reflecting the channel on which the callsign was most recently heard.

* First heard times are saved in addition to last heard times.

* Two new functions, mheard_latest_for_channel and mheard_latest_for_is, are exposed from the mheard code, for use by the AGWPE server code. These two functions parallel the separation between the existing mheard_save_rf and mheard_save_is functions.

* The AGWPE server responds to 'H' frame requests by constructing and returning 20 'H' frame responses (including blank responses if fewer stations have been heard). The responses include both the text and binary forms of the first and last heard times, as described in the AGWPE spec.

* Macros are used to wrap the platform differences for qsort_r / qsort_s, needed to sort heard times on a per-channel basis.

Tested on Linux Mint 22.1, macOS Sequoia 15.6.1, and Windows 10.