### PR TITLE
Add new build config for Direwolf with Hamlib on Windows

### DIFF
--- a/.github/scripts/download_hamlib.py
+++ b/.github/scripts/download_hamlib.py
@@ -1,0 +1,100 @@
+#
+#    This file is part of Dire Wolf, an amateur radio packet TNC.
+#
+#    Copyright (C) 2025, Martin F N Cooper, KD6YAM
+#
+# Purpose: Download and unzip the latest 4.x release of Hamlib.
+#
+
+import json
+import pathlib
+import sys
+import urllib.request
+import zipfile
+
+#
+# Step 1: Obtain target directory from the command line.
+#
+
+if len(sys.argv) != 2:
+    print('Usage: python hamlib_download.py <target-directory>')
+    exit(1)
+
+target_dir = pathlib.Path(sys.argv[1])
+
+#
+# Step 2: Identify the latest 4.x release.
+#
+# We do not want the latest release per se, since that could be a later major
+# version with an incompatible API. Thus we need to identify the latest 4.x
+# release. We do that by querying GitHub for data on all of the releases and
+# finding the tag with the greatest 4.x value.
+#
+# For information on the relevant GitHub JSON API, see:
+#   https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases-for-a-repository
+#
+
+# Download the release data
+
+LIST_RELEASES_URL = 'https://api.github.com/repos/Hamlib/Hamlib/releases'
+
+GITHUB_API_HEADERS = {
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28'
+}
+
+req = urllib.request.Request(LIST_RELEASES_URL, headers=GITHUB_API_HEADERS)
+with urllib.request.urlopen(req) as f:
+    data = json.loads(f.read())
+
+# Find the latest 4.x release, by tag
+
+tags = [r['tag_name'] for r in data]
+version = next(reversed(sorted([t for t in tags if t.startswith('4.')])))
+release = [r for r in data if r['tag_name'] == version][0]
+
+#
+# Step 3: Identify the URL for the Windows zip file.
+#
+# Most Hamlib release files include the version number in the filename, so to
+# find the URL with which to download the zip file, we need to construct the
+# filename based on the version number. Then we use the filename to look up
+# the corresponding asset in the downloaded JSON data, and locate what is
+# known as the "browser download URL".
+#
+
+zipfile_root = f'hamlib-w64-{version}'
+zipfile_name = f'{zipfile_root}.zip'
+asset = [a for a in release['assets'] if a['name'] == zipfile_name][0]
+download_url = asset['browser_download_url']
+
+#
+# Step 4: Download and unzip the release.
+#
+
+target_dir.mkdir(parents=True, exist_ok=True)
+target_file = target_dir / zipfile_name
+
+urllib.request.urlretrieve(download_url, target_file)
+
+zip_file = zipfile.ZipFile(target_file)
+zip_file.extractall(target_dir)
+
+#
+# Step 5: Rename the top level directory.
+#
+# The zip file structure has a top level directory that has the same name as
+# the zip file itself, thus including the version number. We rename that
+# directory to simply 'hamlib' to avoid the need for the version number to be
+# known outside this script.
+#
+
+orig_dir = target_dir / zipfile_root
+norm_dir = target_dir / 'hamlib'
+
+orig_dir.rename(norm_dir)
+
+#
+# End
+#
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,18 @@ jobs:
               build_type: 'Release',
               cmake_extra_flags: '-G "MinGW Makefiles"'
             }
+          - {
+              name: 'Windows Latest MinGW 64bit with Hamlib',
+              os: windows-latest,
+              cc: 'x86_64-w64-mingw32-gcc',
+              cxx: 'x86_64-w64-mingw32-g++',
+              ar: 'x86_64-w64-mingw32-ar',
+              windres: 'x86_64-w64-mingw32-windres',
+              arch: 'x86_64',
+              build_type: 'Release',
+              cmake_extra_flags: '-G "MinGW Makefiles"',
+              windows_hamlib: true
+            }
 # It seems that the MinGW 32 bit target is no longer supported
 # for the github runner.  There might be a work-around, but for
 # now, disable it so we don't get the annoying failure message.
@@ -101,6 +113,12 @@ jobs:
       - name: create build environment
         run: |
           cmake -E make_directory ${{github.workspace}}/build
+      - name: download hamlib for Windows
+        if: ${{ matrix.config.windows_hamlib }}
+        shell: bash
+        run: |
+          python .github/scripts/download_hamlib.py ${{github.workspace}}/build/hamlib
+          echo "HAMLIB_DEFINE=-DHAMLIB_ROOT_DIR=${{github.workspace}}/build/hamlib/hamlib" >> "$GITHUB_ENV"
       - name: configure
         shell: bash
         working-directory: ${{github.workspace}}/build
@@ -117,7 +135,8 @@ jobs:
             -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} \
             -DCMAKE_CXX_FLAGS="-Werror" -DUNITTEST=1 \
             ${{ matrix.config.cmake_extra_flags }} \
-            ${{ github.event.inputs.cmake_flags }}
+            ${{ github.event.inputs.cmake_flags }} \
+            $HAMLIB_DEFINE
       - name: build
         shell: bash
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
               arch: 'x86_64',
               build_type: 'Release',
               cmake_extra_flags: '-G "MinGW Makefiles"',
-              windows_hamlib: true
+              windows_hamlib: true,
+              hamlib_suffix: '-hamlib'
             }
 # It seems that the MinGW 32 bit target is no longer supported
 # for the github runner.  There might be a work-around, but for
@@ -117,8 +118,9 @@ jobs:
         if: ${{ matrix.config.windows_hamlib }}
         shell: bash
         run: |
-          python .github/scripts/download_hamlib.py ${{github.workspace}}/build/hamlib
-          echo "HAMLIB_DEFINE=-DHAMLIB_ROOT_DIR=${{github.workspace}}/build/hamlib/hamlib" >> "$GITHUB_ENV"
+          WORKSPACE_PATH=$(echo "/${{github.workspace}}" | sed -e 's/\\/\//g ; s/://g')
+          python .github/scripts/download_hamlib.py $WORKSPACE_PATH/build/hamlib
+          echo "HAMLIB_DEFINE=-DHAMLIB_ROOT_DIR=$WORKSPACE_PATH/build/hamlib/hamlib" >> "$GITHUB_ENV"
       - name: configure
         shell: bash
         working-directory: ${{github.workspace}}/build
@@ -167,7 +169,7 @@ jobs:
       - name: archive binary
         uses: actions/upload-artifact@v4
         with:
-          name: direwolf_${{ matrix.config.os }}_${{ matrix.config.arch }}_${{ github.sha }}
+          name: direwolf${{ matrix.config.hamlib_suffix }}_${{ matrix.config.os }}_${{ matrix.config.arch }}_${{ github.sha }}
           path: |
             ${{github.workspace}}/build/direwolf-*.zip
             ${{github.workspace}}/build/direwolf.conf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,9 @@ endif()
 find_package(hamlib)
 if(HAMLIB_FOUND)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_HAMLIB")
+  if(WIN32 OR CYGWIN)
+    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-hamlib")
+  endif()
 else()
   set(HAMLIB_INCLUDE_DIRS "")
   set(HAMLIB_LIBRARIES "")
@@ -468,6 +471,11 @@ add_subdirectory(man)
 if (LINUX OR FREEBSD)
   install(FILES ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.desktop DESTINATION share/applications)
   install(FILES ${CMAKE_SOURCE_DIR}/cmake/cpack/${CMAKE_PROJECT_NAME}_icon.png DESTINATION share/pixmaps)
+endif()
+
+# install hamlib DLLs on Windows
+if ((WIN32 OR CYGWIN) AND HAMLIB_FOUND)
+  install(FILES ${HAMLIB_DLLS} DESTINATION ${INSTALL_BIN_DIR})
 endif()
 
 ############ uninstall target ################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,9 +473,11 @@ if (LINUX OR FREEBSD)
   install(FILES ${CMAKE_SOURCE_DIR}/cmake/cpack/${CMAKE_PROJECT_NAME}_icon.png DESTINATION share/pixmaps)
 endif()
 
-# install hamlib DLLs on Windows
+# install hamlib DLLs and license files on Windows
 if ((WIN32 OR CYGWIN) AND HAMLIB_FOUND)
   install(FILES ${HAMLIB_DLLS} DESTINATION ${INSTALL_BIN_DIR})
+  install(FILES ${HAMLIB_ROOT_DIR}/COPYING.LIB.txt DESTINATION ${INSTALL_DOC_DIR} RENAME hamlib-COPYING.LIB.txt)
+  install(FILES ${HAMLIB_ROOT_DIR}/LICENSE.txt DESTINATION ${INSTALL_DOC_DIR} RENAME hamlib-LICENSE.txt)
 endif()
 
 ############ uninstall target ################

--- a/cmake/modules/Findhamlib.cmake
+++ b/cmake/modules/Findhamlib.cmake
@@ -30,6 +30,8 @@ find_path(HAMLIB_INCLUDE_DIR
   HINTS
   ${PC_HAMLIB_INCLUDEDIR}
   ${HAMLIB_ROOT_DIR}
+  PATH_SUFFIXES
+  include
   )
 
 find_library(HAMLIB_LIBRARY
@@ -48,7 +50,8 @@ find_library(HAMLIB_LIBRARY
   HINTS
   ${PC_HAMLIB_LIBDIR}
   ${HAMLIB_ROOT_DIR}
-
+  PATH_SUFFIXES
+  lib/gcc
   )
 
 include(FindPackageHandleStandardArgs)
@@ -61,6 +64,9 @@ find_package_handle_standard_args(hamlib
 if(HAMLIB_FOUND)
   list(APPEND HAMLIB_LIBRARIES ${HAMLIB_LIBRARY})
   list(APPEND HAMLIB_INCLUDE_DIRS ${HAMLIB_INCLUDE_DIR})
+  if(WIN32 OR CYGWIN)
+    file(GLOB HAMLIB_DLLS ${HAMLIB_ROOT_DIR}/bin/*.dll)
+  endif()
   mark_as_advanced(HAMLIB_ROOT_DIR)
 endif()
 


### PR DESCRIPTION
In parallel with the existing 64-bit Windows build, these changes add a new matrix config for the same build but including Hamlib as part of the build and package distribution. The resultant package zip file has "-hamlib" appended to the name to distinguish it from the standard Windows build.

Installing Hamlib as a build dependency using a package manager isn't a viable option on Windows. Instead, we interrogate the GitHub release assets to find the latest 4.x release of Hamlib, download and expand the zip file for that release, and provide the path to the directory for CMake configuration.