### PR TITLE
fix: Break when failing to create AX.25 frame from AGWPE M frame

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2075,6 +2075,7 @@ static THREAD_F cmd_listen_thread (void *arg)
 		if (pp == NULL) {
 	          text_color_set(DW_COLOR_ERROR);
 		  dw_printf ("Failed to create frame from AGW 'M' message.\n");
+			break;
 		}
 
 	        ax25_set_info (pp, (unsigned char*)cmd.data, data_len);


### PR DESCRIPTION
Without this, the command handler will go on to try to process and enqueue a null packet