### PR TITLE
Add an option to monitor own frames in AGWPE, since the spec is ambiguous

### DIFF
--- a/src/ax25_link.c
+++ b/src/ax25_link.c
@@ -1928,6 +1928,20 @@ void dl_client_cleanup (dlq_item_t *E)
 	  dw_printf ("dl_client_cleanup (%d)\n", E->client);
 	}
 
+/*
+ * Stale cleanup guard: if the server slot generation has been bumped since
+ * this cleanup item was queued (meaning a new client connected to the same
+ * slot before we got here), do NOT tear down the AX.25 streams or remove
+ * the callsign registrations — those belong to the new client session.
+ */
+	if (E->client_generation != server_client_generation (E->client)) {
+	  if (s_debug_client_app) {
+	    text_color_set(DW_COLOR_INFO);
+	    dw_printf ("dl_client_cleanup (%d): stale (generation mismatch), skipping.\n", E->client);
+	  }
+	  return;
+	}
+
 
 	dlprev = NULL;
 	S = list_head;

--- a/src/config.c
+++ b/src/config.c
@@ -5008,6 +5008,14 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 	  }
 
 /*
+ * AGWPE_OWN_MONITOR		- Monitor own transmitted frames of all types, not just UNPROTO.
+ */
+
+	  else if (strcasecmp(t, "AGWPE_OWN_MONITOR") == 0) {
+	    p_misc_config->agwpe_own_monitor = 1;
+	  }
+
+/*
  * KISSPORT port [ chan ]		- Port number for KISS over IP.
  */
 

--- a/src/config.h
+++ b/src/config.h
@@ -36,6 +36,8 @@ struct misc_config_s {
 
 	int agwpe_port;		/* TCP Port number for the "AGW TCPIP Socket Interface" */
 
+	int agwpe_own_monitor;	/* True to monitor own transmitted frames of all types, not just UNPROTO. */
+
 	// Previously we allowed only a single TCP port for KISS.
 	// An increasing number of people want to run multiple radios.
 	// Unfortunately, most applications don't know how to deal with multi-radio TNCs.

--- a/src/direwolf.h
+++ b/src/direwolf.h
@@ -278,6 +278,10 @@ typedef pthread_mutex_t dw_mutex_t;
 #endif
 #define SOCK_RECV(s,data,size) recv(s,data,size,0)
 
+/* Non-blocking send and TCP keepalive helpers are in sock_utils.h.
+ * Include that header after the platform socket headers in files that need them.
+ */
+
 
 /* Platform differences for string functions. */
 

--- a/src/dlq.c
+++ b/src/dlq.c
@@ -982,7 +982,7 @@ void dlq_seize_confirm (int chan)
  *
  *--------------------------------------------------------------------*/
 
-void dlq_client_cleanup (int client)
+void dlq_client_cleanup (int client, int generation)
 {
 	struct dlq_item_s *pnew;
 #if DEBUG
@@ -1007,6 +1007,7 @@ void dlq_client_cleanup (int client)
 	pnew->unique_id = s_new_count;
 	pnew->type = DLQ_CLIENT_CLEANUP;
 	pnew->client = client;
+	pnew->client_generation = generation;
 
 /* Put it into queue. */
 

--- a/src/dlq.h
+++ b/src/dlq.h
@@ -99,6 +99,12 @@ typedef struct dlq_item_s {
 
 	int client;
 
+	int client_generation;		/* For DLQ_CLIENT_CLEANUP: the server slot generation
+					 * at the time this item was queued.  If the generation
+					 * has been bumped (a new client connected to this slot)
+					 * before this item is processed, the cleanup is stale
+					 * and must be discarded. */
+
 
 // Used only by client request to transmit connected data.
 
@@ -139,7 +145,7 @@ void dlq_channel_busy (int chan, int activity, int status);
 
 void dlq_seize_confirm (int chan);
 
-void dlq_client_cleanup (int client);
+void dlq_client_cleanup (int client, int generation);
 
 
 

--- a/src/kissnet.c
+++ b/src/kissnet.c
@@ -199,6 +199,7 @@ same direwolf instance.
 #include "kissnet.h"
 #include "kiss_frame.h"
 #include "xmit.h"
+#include "sock_utils.h"
 
 void hex_dump (unsigned char *p, int len);	// This should be in a .h file.
 
@@ -528,6 +529,8 @@ static THREAD_F connect_listen_thread (void *arg)
               return (0);
             }
 
+	    SOCK_SET_KEEPALIVE(kps->client_sock[client]);
+
 	    text_color_set(DW_COLOR_INFO);
 	    if (kps->chan == -1) {
 	      dw_printf("\nAttached to KISS TCP client application %d on port %s ...\n\n", client, tcp_port_str);
@@ -636,6 +639,8 @@ static THREAD_F connect_listen_thread (void *arg)
 	    }
 
             kps->client_sock[client] = accept(listen_sock, (struct sockaddr*)(&sockaddr),&sockaddr_size);
+
+	    SOCK_SET_KEEPALIVE(kps->client_sock[client]);
 
 	    text_color_set(DW_COLOR_INFO);
 	    if (kps->chan == -1) {
@@ -785,24 +790,18 @@ void kissnet_send_rec_packet (int chan, int kiss_cmd, unsigned char *fbuf, int f
 	            }
 	          }
 
-#if __WIN32__	
-                  err = SOCK_SEND(kps->client_sock[client], (char*)kiss_buff, kiss_len);
-	          if (err == SOCKET_ERROR) {
-	            text_color_set(DW_COLOR_ERROR);
-	            dw_printf ("\nError %d sending message to KISS client application %d on port %d.  Closing connection.\n\n", WSAGetLastError(), client, kps->tcp_port);
-	            closesocket (kps->client_sock[client]);
-	            kps->client_sock[client] = -1;
-	            WSACleanup();
-	          }
-#else
-                  err = SOCK_SEND (kps->client_sock[client], kiss_buff, kiss_len);
+                  err = SOCK_SEND_NOWAIT (kps->client_sock[client], (char*)kiss_buff, kiss_len);
 	          if (err <= 0) {
 	            text_color_set(DW_COLOR_ERROR);
-	            dw_printf ("\nError %d sending message to KISS client application %d on port %d.  Closing connection.\n\n", err, client, kps->tcp_port);
+	            dw_printf ("\nError sending message to KISS client application %d on port %d.  Closing connection.\n\n", client, kps->tcp_port);
+#if __WIN32__
+	            closesocket (kps->client_sock[client]);
+	            WSACleanup();
+#else
 	            close (kps->client_sock[client]);
+#endif
 	            kps->client_sock[client] = -1;
 	          }
-#endif
 	        } // frame length >= 0
 	      } // if all clients or the one specifie
 	    } // for each client on the tcp port
@@ -882,24 +881,18 @@ void kissnet_copy (unsigned char *in_msg, int in_len, int chan, int cmd, struct 
 	              kiss_debug_print (TO_CLIENT, NULL, kiss_buff, kiss_len);
 	            }
 
-#if __WIN32__
-                    err = SOCK_SEND(kps->client_sock[client], (char*)kiss_buff, kiss_len);
-	            if (err == SOCKET_ERROR) {
-	              text_color_set(DW_COLOR_ERROR);
-	              dw_printf ("\nError %d copying message to KISS TCP port %d client %d application.  Closing connection.\n\n", WSAGetLastError(), kps->tcp_port, client);
-	              closesocket (kps->client_sock[client]);
-	              kps->client_sock[client] = -1;
-	              WSACleanup();
-	            }
-#else
-                    err = SOCK_SEND (kps->client_sock[client], kiss_buff, kiss_len);
+                    err = SOCK_SEND_NOWAIT (kps->client_sock[client], (char*)kiss_buff, kiss_len);
 	            if (err <= 0) {
 	              text_color_set(DW_COLOR_ERROR);
 	              dw_printf ("\nError copying message to KISS TCP port %d client %d application.  Closing connection.\n\n", kps->tcp_port, client);
+#if __WIN32__
+	              closesocket (kps->client_sock[client]);
+	              WSACleanup();
+#else
 	              close (kps->client_sock[client]);
+#endif
 	              kps->client_sock[client] = -1;
 	            }
-#endif
 	          } // Channel is allowed on this port.
 	        } // socket is open
 	      } // if origin and destination different.

--- a/src/kissnet.c
+++ b/src/kissnet.c
@@ -792,15 +792,20 @@ void kissnet_send_rec_packet (int chan, int kiss_cmd, unsigned char *fbuf, int f
 
                   err = SOCK_SEND_NOWAIT (kps->client_sock[client], (char*)kiss_buff, kiss_len);
 	          if (err <= 0) {
-	            text_color_set(DW_COLOR_ERROR);
-	            dw_printf ("\nError sending message to KISS client application %d on port %d.  Closing connection.\n\n", client, kps->tcp_port);
+	            if (SOCK_SEND_IS_TRANSIENT()) {
+	              text_color_set(DW_COLOR_ERROR);
+	              dw_printf ("\nKISS TCP port %d client %d buffer full; dropping frame.\n\n", kps->tcp_port, client);
+	            } else {
+	              text_color_set(DW_COLOR_ERROR);
+	              dw_printf ("\nError sending message to KISS client application %d on port %d.  Closing connection.\n\n", client, kps->tcp_port);
 #if __WIN32__
-	            closesocket (kps->client_sock[client]);
-	            WSACleanup();
+	              closesocket (kps->client_sock[client]);
+	              WSACleanup();
 #else
-	            close (kps->client_sock[client]);
+	              close (kps->client_sock[client]);
 #endif
-	            kps->client_sock[client] = -1;
+	              kps->client_sock[client] = -1;
+	            }
 	          }
 	        } // frame length >= 0
 	      } // if all clients or the one specifie
@@ -883,15 +888,20 @@ void kissnet_copy (unsigned char *in_msg, int in_len, int chan, int cmd, struct 
 
                     err = SOCK_SEND_NOWAIT (kps->client_sock[client], (char*)kiss_buff, kiss_len);
 	            if (err <= 0) {
-	              text_color_set(DW_COLOR_ERROR);
-	              dw_printf ("\nError copying message to KISS TCP port %d client %d application.  Closing connection.\n\n", kps->tcp_port, client);
+	              if (SOCK_SEND_IS_TRANSIENT()) {
+	                text_color_set(DW_COLOR_ERROR);
+	                dw_printf ("\nKISS TCP port %d client %d buffer full; dropping frame.\n\n", kps->tcp_port, client);
+	              } else {
+	                text_color_set(DW_COLOR_ERROR);
+	                dw_printf ("\nError copying message to KISS TCP port %d client %d application.  Closing connection.\n\n", kps->tcp_port, client);
 #if __WIN32__
-	              closesocket (kps->client_sock[client]);
-	              WSACleanup();
+	                closesocket (kps->client_sock[client]);
+	                WSACleanup();
 #else
-	              close (kps->client_sock[client]);
+	                close (kps->client_sock[client]);
 #endif
-	              kps->client_sock[client] = -1;
+	                kps->client_sock[client] = -1;
+	              }
 	            }
 	          } // Channel is allowed on this port.
 	        } // socket is open

--- a/src/server.c
+++ b/src/server.c
@@ -485,6 +485,7 @@ static void format_heard_time(time_t heard, char *time_str, char *time_bin)
  *--------------------------------------------------------------------*/
 
 static struct audio_s *save_audio_config_p;
+static struct misc_config_s *save_misc_config_p;
 
 
 void server_init (struct audio_s *audio_config_p, struct misc_config_s *mc)
@@ -509,6 +510,7 @@ void server_init (struct audio_s *audio_config_p, struct misc_config_s *mc)
 #endif
 
 	save_audio_config_p = audio_config_p;
+	save_misc_config_p = mc;
 
 	for (client=0; client<MAX_NET_CLIENTS; client++) {
 	  client_sock[client] = -1;
@@ -963,7 +965,7 @@ void server_send_monitored (int chan, packet_t pp, int own_xmit)
 	    if (own_xmit) {
 	      // Should we include all own transmitted frames or only UNPROTO?
 	      // Discussion:  https://github.com/wb2osz/direwolf/issues/585
-	      if (agwpe_msg.hdr.datakind != 'U') {
+	      if (agwpe_msg.hdr.datakind != 'U' && !(save_misc_config_p != NULL && save_misc_config_p->agwpe_own_monitor)) {
 	        break;
 	      }
 	      agwpe_msg.hdr.datakind = 'T';

--- a/src/server.c
+++ b/src/server.c
@@ -167,6 +167,7 @@
 #include "audio.h"
 #include "server.h"
 #include "dlq.h"
+#include "sock_utils.h"
 #include "mheard.h"
 
 
@@ -706,6 +707,8 @@ static THREAD_F connect_listen_thread (void *arg)
               return (0);
             }
 
+	    SOCK_SET_KEEPALIVE(client_sock[client]);
+
 	    text_color_set(DW_COLOR_INFO);
 	    dw_printf("\nAttached to AGW client application %d ...\n\n", client);
 
@@ -797,6 +800,8 @@ static THREAD_F connect_listen_thread (void *arg)
          
             client_sock[client] = accept(listen_sock, (struct sockaddr*)(&sockaddr),&sockaddr_size);
 
+	    SOCK_SET_KEEPALIVE(client_sock[client]);
+
 	    text_color_set(DW_COLOR_INFO);
 	    dw_printf("\nAttached to AGW client application %d...\n\n", client);
 
@@ -880,28 +885,20 @@ void server_send_rec_packet (int chan, packet_t pp, unsigned char *fbuf,  int fl
 	      debug_print (TO_CLIENT, client, &agwpe_msg.hdr, sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
 	    }
 
-#if __WIN32__	
-            err = SOCK_SEND (client_sock[client], (char*)(&agwpe_msg), sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
-	    if (err == SOCKET_ERROR)
-	    {
-	      text_color_set(DW_COLOR_ERROR);
-	      dw_printf ("\nError %d sending message to AGW client application.  Closing connection.\n\n", WSAGetLastError());
-	      closesocket (client_sock[client]);
-	      client_sock[client] = -1;
-	      WSACleanup();
-	      dlq_client_cleanup (client);
-	    }
-#else
-            err = SOCK_SEND (client_sock[client], &agwpe_msg, sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
+            err = SOCK_SEND_NOWAIT (client_sock[client], (char*)(&agwpe_msg), sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
 	    if (err <= 0)
 	    {
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("\nError sending message to AGW client application.  Closing connection.\n\n");
+#if __WIN32__
+	      closesocket (client_sock[client]);
+	      WSACleanup();
+#else
 	      close (client_sock[client]);
-	      client_sock[client] = -1;    
+#endif
+	      client_sock[client] = -1;
 	      dlq_client_cleanup (client);
 	    }
-#endif
 	  }
 	}
 
@@ -1001,28 +998,20 @@ void server_send_monitored (int chan, packet_t pp, int own_xmit)
 	      debug_print (TO_CLIENT, client, &agwpe_msg.hdr, sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
 	    }
 
-#if __WIN32__
-            err = SOCK_SEND (client_sock[client], (char*)(&agwpe_msg), sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
-	    if (err == SOCKET_ERROR)
-	    {
-	      text_color_set(DW_COLOR_ERROR);
-	      dw_printf ("\nError %d sending message to AGW client application %d.  Closing connection.\n\n", WSAGetLastError(), client);
-	      closesocket (client_sock[client]);
-	      client_sock[client] = -1;
-	      WSACleanup();
-	      dlq_client_cleanup (client);
-	    }
-#else
-            err = SOCK_SEND (client_sock[client], &agwpe_msg, sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
+            err = SOCK_SEND_NOWAIT (client_sock[client], (char*)(&agwpe_msg), sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
 	    if (err <= 0)
 	    {
 	      text_color_set(DW_COLOR_ERROR);
 	      dw_printf ("\nError sending message to AGW client application %d.  Closing connection.\n\n", client);
+#if __WIN32__
+	      closesocket (client_sock[client]);
+	      WSACleanup();
+#else
 	      close (client_sock[client]);
+#endif
 	      client_sock[client] = -1;
 	      dlq_client_cleanup (client);
 	    }
-#endif
 	  }
 	}
 
@@ -1442,8 +1431,19 @@ static void send_to_client (int client, void *reply_p)
 	  debug_print (TO_CLIENT, client, ph, len);
 	}
 
-	err = SOCK_SEND (client_sock[client], (char*)(ph), len);
-	(void)err;
+	err = SOCK_SEND_NOWAIT (client_sock[client], (char*)(ph), len);
+	if (err <= 0) {
+	  text_color_set(DW_COLOR_ERROR);
+	  dw_printf ("\nError sending message to AGW client application.  Closing connection.\n\n");
+#if __WIN32__
+	  closesocket (client_sock[client]);
+	  WSACleanup();
+#else
+	  close (client_sock[client]);
+#endif
+	  client_sock[client] = -1;
+	  dlq_client_cleanup (client);
+	}
 }
 
 

--- a/src/server.c
+++ b/src/server.c
@@ -189,6 +189,14 @@ static int client_sock[MAX_NET_CLIENTS];
 					/* Set to -1 if not connected. */
 					/* (Don't use SOCKET type because it is unsigned.) */
 
+static int client_generation[MAX_NET_CLIENTS];
+					/* Incremented each time a new client connects to this slot.
+					 * Each DLQ_CLIENT_CLEANUP item carries the generation at the
+					 * time it was queued.  If the generation has advanced before
+					 * the item is processed (a new client reconnected before the
+					 * stale cleanup ran), dl_client_cleanup skips the cleanup so
+					 * the freshly registered callsigns are not wiped. */
+
 static int enable_send_raw_to_client[MAX_NET_CLIENTS];
 					/* Should we send received packets to client app in raw form? */
 					/* Note that it starts as false for a new connection. */
@@ -303,6 +311,27 @@ static int debug_client = 0;		/* Debug option: Print information flowing from an
 void server_set_debug (int n) 
 {	
 	debug_client = n;
+}
+
+
+/*-------------------------------------------------------------------
+ * Name:        server_client_generation
+ *
+ * Purpose:     Return the current generation counter for a client slot.
+ *              Used by dl_client_cleanup (ax25_link.c) to detect whether
+ *              a DLQ_CLIENT_CLEANUP item is stale (i.e. a new client
+ *              reconnected to this slot before the deferred cleanup ran).
+ *
+ * Inputs:      client  - slot index [0, MAX_NET_CLIENTS)
+ *
+ * Returns:     Generation counter value.  Starts at 0, incremented by 1
+ *              each time a new client connects to this slot.
+ *--------------------------------------------------------------------*/
+
+int server_client_generation (int client)
+{
+	assert (client >= 0 && client < MAX_NET_CLIENTS);
+	return client_generation[client];
 }
 
 void hex_dump (unsigned char *p, int len) 
@@ -515,6 +544,7 @@ void server_init (struct audio_s *audio_config_p, struct misc_config_s *mc)
 
 	for (client=0; client<MAX_NET_CLIENTS; client++) {
 	  client_sock[client] = -1;
+	  client_generation[client] = 0;
 	  enable_send_raw_to_client[client] = 0;
 	  enable_send_monitor_to_client[client] = 0;
 	}
@@ -709,6 +739,8 @@ static THREAD_F connect_listen_thread (void *arg)
 
 	    SOCK_SET_KEEPALIVE(client_sock[client]);
 
+	    client_generation[client]++;
+
 	    text_color_set(DW_COLOR_INFO);
 	    dw_printf("\nAttached to AGW client application %d ...\n\n", client);
 
@@ -802,6 +834,8 @@ static THREAD_F connect_listen_thread (void *arg)
 
 	    SOCK_SET_KEEPALIVE(client_sock[client]);
 
+	    client_generation[client]++;
+
 	    text_color_set(DW_COLOR_INFO);
 	    dw_printf("\nAttached to AGW client application %d...\n\n", client);
 
@@ -888,16 +922,21 @@ void server_send_rec_packet (int chan, packet_t pp, unsigned char *fbuf,  int fl
             err = SOCK_SEND_NOWAIT (client_sock[client], (char*)(&agwpe_msg), sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
 	    if (err <= 0)
 	    {
-	      text_color_set(DW_COLOR_ERROR);
-	      dw_printf ("\nError sending message to AGW client application.  Closing connection.\n\n");
+	      if (SOCK_SEND_IS_TRANSIENT()) {
+	        text_color_set(DW_COLOR_ERROR);
+	        dw_printf ("\nAGW client %d TCP buffer full; dropping packet frame.\n\n", client);
+	      } else {
+	        text_color_set(DW_COLOR_ERROR);
+	        dw_printf ("\nError sending message to AGW client application.  Closing connection.\n\n");
 #if __WIN32__
-	      closesocket (client_sock[client]);
-	      WSACleanup();
+	        closesocket (client_sock[client]);
+	        WSACleanup();
 #else
-	      close (client_sock[client]);
+	        close (client_sock[client]);
 #endif
-	      client_sock[client] = -1;
-	      dlq_client_cleanup (client);
+	        client_sock[client] = -1;
+	        dlq_client_cleanup (client, client_generation[client]);
+	      }
 	    }
 	  }
 	}
@@ -1001,16 +1040,21 @@ void server_send_monitored (int chan, packet_t pp, int own_xmit)
             err = SOCK_SEND_NOWAIT (client_sock[client], (char*)(&agwpe_msg), sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
 	    if (err <= 0)
 	    {
-	      text_color_set(DW_COLOR_ERROR);
-	      dw_printf ("\nError sending message to AGW client application %d.  Closing connection.\n\n", client);
+	      if (SOCK_SEND_IS_TRANSIENT()) {
+	        text_color_set(DW_COLOR_ERROR);
+	        dw_printf ("\nAGW client %d TCP buffer full; dropping monitor frame.\n\n", client);
+	      } else {
+	        text_color_set(DW_COLOR_ERROR);
+	        dw_printf ("\nError sending message to AGW client application %d.  Closing connection.\n\n", client);
 #if __WIN32__
-	      closesocket (client_sock[client]);
-	      WSACleanup();
+	        closesocket (client_sock[client]);
+	        WSACleanup();
 #else
-	      close (client_sock[client]);
+	        close (client_sock[client]);
 #endif
-	      client_sock[client] = -1;
-	      dlq_client_cleanup (client);
+	        client_sock[client] = -1;
+	        dlq_client_cleanup (client, client_generation[client]);
+	      }
 	    }
 	  }
 	}
@@ -1415,6 +1459,9 @@ static void send_to_client (int client, void *reply_p)
 	int len;
 	int err;
 
+	/* Socket may have been closed already by a previous failed send or disconnect. */
+	if (client_sock[client] <= 0) return;
+
 	ph = (struct agwpe_s *) reply_p;	// Replies are often hdr + other stuff.
 
 	len = sizeof(struct agwpe_s) + netle2host(ph->data_len_NETLE);
@@ -1442,7 +1489,7 @@ static void send_to_client (int client, void *reply_p)
 	  close (client_sock[client]);
 #endif
 	  client_sock[client] = -1;
-	  dlq_client_cleanup (client);
+	  dlq_client_cleanup (client, client_generation[client]);
 	}
 }
 
@@ -1481,7 +1528,7 @@ static THREAD_F cmd_listen_thread (void *arg)
 	    close (client_sock[client]);
 #endif
 	    client_sock[client] = -1;
-	    dlq_client_cleanup (client);
+	    dlq_client_cleanup (client, client_generation[client]);
 	    continue;
 	  }
 
@@ -1527,7 +1574,7 @@ static THREAD_F cmd_listen_thread (void *arg)
 	    close (client_sock[client]);
 #endif
 	    client_sock[client] = -1;
-	    dlq_client_cleanup (client);
+	    dlq_client_cleanup (client, client_generation[client]);
 	    return (0);
 	  }
 
@@ -1546,7 +1593,7 @@ static THREAD_F cmd_listen_thread (void *arg)
 	      close (client_sock[client]);
 #endif
 	      client_sock[client] = -1;
-	      dlq_client_cleanup (client);
+	      dlq_client_cleanup (client, client_generation[client]);
 	      return (0);
 	    }
 	    if (n >= 0) {

--- a/src/server.h
+++ b/src/server.h
@@ -11,6 +11,8 @@
 
 void server_set_debug (int n);
 
+int server_client_generation (int client);
+
 void server_init (struct audio_s *audio_config_p, struct misc_config_s *misc_config);
 
 void server_send_rec_packet (int chan, packet_t pp, unsigned char *fbuf,  int flen);

--- a/src/sock_utils.h
+++ b/src/sock_utils.h
@@ -1,0 +1,98 @@
+/* sock_utils.h - Non-blocking send and keepalive helpers for TCP client sockets.
+ *
+ * Include this AFTER the platform socket headers (<sys/socket.h> on Unix,
+ * <winsock2.h> on Windows) since the inline functions reference socket types.
+ */
+
+#ifndef SOCK_UTILS_H
+#define SOCK_UTILS_H 1
+
+/*------------------------------------------------------------------
+ * SOCK_SEND_NOWAIT  --  non-blocking send
+ *
+ * Returns immediately with an error if the kernel TCP send buffer is
+ * full, instead of blocking until space becomes available.  Use on
+ * any path that must not stall recv_process (the sole DLQ consumer).
+ *
+ * Linux/macOS: MSG_DONTWAIT flag does this in one call.
+ * Windows:     A zero-timeout select() checks writability first.
+ *------------------------------------------------------------------*/
+
+#if __WIN32__
+
+static inline int sock_send_nowait (SOCKET s, const char *data, int size) {
+    fd_set wfds;
+    struct timeval tv;
+    FD_ZERO(&wfds);
+    FD_SET(s, &wfds);
+    tv.tv_sec  = 0;
+    tv.tv_usec = 0;
+    if (select(0, NULL, &wfds, NULL, &tv) <= 0) {
+        WSASetLastError(WSAEWOULDBLOCK);
+        return SOCKET_ERROR;
+    }
+    return send(s, data, size, 0);
+}
+#define SOCK_SEND_NOWAIT(s,data,size) sock_send_nowait((SOCKET)(s),(const char*)(data),(size))
+
+#elif __APPLE__
+#define SOCK_SEND_NOWAIT(s,data,size) send(s,data,size, MSG_DONTWAIT)
+#else
+#define SOCK_SEND_NOWAIT(s,data,size) send(s,data,size, MSG_NOSIGNAL|MSG_DONTWAIT)
+#endif
+
+
+/*------------------------------------------------------------------
+ * SOCK_SET_KEEPALIVE  --  enable TCP keepalives on an accepted socket
+ *
+ * Detects stale connections (e.g. client laptop suspended without
+ * cleanly closing the TCP session) within ~2 minutes instead of the
+ * OS default of 2 hours.
+ *
+ * Settings: 60 s idle before first probe, 10 s between probes, 6
+ * probes → connection declared dead after ~120 s of silence.
+ *
+ * TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT are Linux/macOS
+ * extensions guarded with #ifdef so the code still compiles on
+ * platforms that lack them (they just use the OS defaults).
+ * On Windows the equivalent is set via WSAIoctl(SIO_KEEPALIVE_VALS).
+ *------------------------------------------------------------------*/
+
+#if __WIN32__
+
+#include <mstcpip.h>
+static inline void sock_set_keepalive (SOCKET s) {
+    BOOL on = TRUE;
+    setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, (const char *)&on, sizeof(on));
+    struct tcp_keepalive ka;
+    ka.onoff             = 1;
+    ka.keepalivetime     = 60000;   /* ms before first probe */
+    ka.keepaliveinterval = 10000;   /* ms between probes     */
+    DWORD ret = 0;
+    WSAIoctl(s, SIO_KEEPALIVE_VALS, &ka, sizeof(ka), NULL, 0, &ret, NULL, NULL);
+}
+#define SOCK_SET_KEEPALIVE(s) sock_set_keepalive((SOCKET)(s))
+
+#else
+
+static inline void sock_set_keepalive (int s) {
+    int on = 1;
+    setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on));
+#ifdef TCP_KEEPIDLE
+    int idle = 60;
+    setsockopt(s, IPPROTO_TCP, TCP_KEEPIDLE,  &idle, sizeof(idle));
+#endif
+#ifdef TCP_KEEPINTVL
+    int intvl = 10;
+    setsockopt(s, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
+#endif
+#ifdef TCP_KEEPCNT
+    int cnt = 6;
+    setsockopt(s, IPPROTO_TCP, TCP_KEEPCNT,   &cnt, sizeof(cnt));
+#endif
+}
+#define SOCK_SET_KEEPALIVE(s) sock_set_keepalive(s)
+
+#endif  /* __WIN32__ */
+
+#endif  /* SOCK_UTILS_H */

--- a/src/sock_utils.h
+++ b/src/sock_utils.h
@@ -43,6 +43,28 @@ static inline int sock_send_nowait (SOCKET s, const char *data, int size) {
 
 
 /*------------------------------------------------------------------
+ * SOCK_SEND_IS_TRANSIENT  --  true when the last SOCK_SEND_NOWAIT
+ * failed only because the kernel TCP send buffer was momentarily
+ * full (EAGAIN / EWOULDBLOCK / WSAEWOULDBLOCK).
+ *
+ * Use this to distinguish "buffer momentarily full, drop this frame
+ * and keep the connection open" from a hard error that means the
+ * remote end has gone away and the socket should be closed.
+ *
+ * Truly frozen clients are handled by the SO_KEEPALIVE probes set
+ * with SOCK_SET_KEEPALIVE: when the OS declares the connection dead
+ * the next send will return a hard error and the socket will be
+ * closed normally.
+ *------------------------------------------------------------------*/
+
+#if __WIN32__
+#define SOCK_SEND_IS_TRANSIENT() (WSAGetLastError() == WSAEWOULDBLOCK)
+#else
+#define SOCK_SEND_IS_TRANSIENT() (errno == EAGAIN || errno == EWOULDBLOCK)
+#endif
+
+
+/*------------------------------------------------------------------
  * SOCK_SET_KEEPALIVE  --  enable TCP keepalives on an accepted socket
  *
  * Detects stale connections (e.g. client laptop suspended without


### PR DESCRIPTION
Recent changes on Direwolf hide the station's own sent frames on AWGPE monitor 'U' messages, which makes monitoring traffic from one's own station awkward, essentially missing half the traffic.

This PR adds a "AGWPE_OWN_MONITOR" config option that, it present, also includes your own stations's sent frames, which essentially reverts back to the older Direwolf behavior, that way everyone can be happy :)

See #585  for context.