### PR TITLE
Add strerror() to error messages for easier diagnosis

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -414,7 +414,7 @@ int audio_open (struct audio_s *pa)
 	          //Create UDP Socket
 	          if ((adev[a].udp_sock=socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP))==-1) {
 	            text_color_set(DW_COLOR_ERROR);
-	            dw_printf ("Couldn't create socket, errno %d\n", errno);
+	            dw_printf ("Couldn't create socket, errno %d (%s)\n", errno, strerror(errno));
 	            return -1;
 	          }
 
@@ -426,7 +426,7 @@ int audio_open (struct audio_s *pa)
 	          //Bind to the socket
 	          if (bind(adev[a].udp_sock, (const struct sockaddr *) &si_me, sizeof(si_me))==-1) {
 	            text_color_set(DW_COLOR_ERROR);
-	            dw_printf ("Couldn't bind socket, errno %d\n", errno);
+	            dw_printf ("Couldn't bind socket, errno %d (%s)\n", errno, strerror(errno));
 	            return -1;
 	          }
 	        }
@@ -823,7 +823,7 @@ static int poll_sndio (struct sio_hdl *hdl, int events)
 	  }
 	  if (poll (pfds, nfds, -1) < 0) {
 	    text_color_set(DW_COLOR_ERROR);
-	    dw_printf ("poll %d\n", errno);
+	    dw_printf ("poll failed, errno %d (%s)\n", errno, strerror(errno));
 	    return (-1);
 	  }
 	  revents = sio_revents (hdl, pfds);

--- a/src/audio_portaudio.c
+++ b/src/audio_portaudio.c
@@ -687,7 +687,7 @@ int audio_open (struct audio_s *pa)
 					//Create UDP Socket
 					if ((adev[a].udp_sock=socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP))==-1) {
 						text_color_set(DW_COLOR_ERROR);
-						dw_printf ("Couldn't create socket, errno %d\n", errno);
+						dw_printf ("Couldn't create socket, errno %d (%s)\n", errno, strerror(errno));
 						return -1;
 					}
 
@@ -699,7 +699,7 @@ int audio_open (struct audio_s *pa)
 					//Bind to the socket
 					if (bind(adev[a].udp_sock, (const struct sockaddr *) &si_me, sizeof(si_me))==-1) {
 						text_color_set(DW_COLOR_ERROR);
-						dw_printf ("Couldn't bind socket, errno %d\n", errno);
+						dw_printf ("Couldn't bind socket, errno %d (%s)\n", errno, strerror(errno));
 						return -1;
 					}
 				}

--- a/src/cm108.c
+++ b/src/cm108.c
@@ -1056,7 +1056,7 @@ static int cm108_write (char *name, int iomask, int iodata)
 	  //  as root		EPIPE           32      /* Broken pipe - Happens if we send 4 bytes */
 
 	  text_color_set(DW_COLOR_ERROR);
-	  dw_printf ("Write to %s failed, n=%d, errno=%d\n", name, n, errno);
+	  dw_printf ("Write to %s failed, n=%d, errno=%d (%s)\n", name, n, errno, strerror(errno));
 
 	  if (errno == EACCES) {
 	    dw_printf ("Type \"ls -l %s\" and verify that it has audio group rw similar to this:\n", name);


### PR DESCRIPTION
Fixes #560.

Error messages that included `errno` numbers now also include the human-readable string from `strerror()`, making failures easier to diagnose without looking up values manually.

For example:

- Before: `Write to /dev/hidraw3 failed, n=-1, errno=32`
- After: `Write to /dev/hidraw3 failed, n=-1, errno=32 (Broken pipe)`

Changes are in three files:

- `src/cm108.c` — `cm108_write()` failure
- `src/audio.c` — UDP socket create/bind failures; sndio poll failure
- `src/audio_portaudio.c` — UDP socket create/bind failures

No logic changes. `strerror()` and `errno` were already included in all three files.

73, Chris 2E0FRU