### PR TITLE
fix: use gmtime_r in get_timestamp for thread safety

### DIFF
--- a/src/decode_aprs.c
+++ b/src/decode_aprs.c
@@ -4034,13 +4034,12 @@ time_t get_timestamp (decode_aprs_t *A, char *p)
 	}
 
 	struct tm *ptm;
-
+	struct tm tm_buf;
 	time_t ts;
 
 	ts = time(NULL);
-	// FIXME: use gmtime_r instead.
-	// Besides not being thread safe, gmtime could possibly return null.
-	ptm = gmtime(&ts);
+	ptm = gmtime_r(&ts, &tm_buf);
+	if (ptm == NULL) return ((time_t)0);
 
 	pdhm = (void *)p;
 	phms = (void *)p;


### PR DESCRIPTION
## Summary

`get_timestamp()` in `decode_aprs.c` calls `gmtime(3)`, which returns a pointer to a static buffer shared across all threads. In a multi-threaded decoder, concurrent timestamp decodes race on that buffer and can corrupt results.

The FIXME comment at line 4041 (present since at least 2016) flags exactly this:

```c
// FIXME: use gmtime_r instead.
// Besides not being thread safe, gmtime could possibly return null.
ptm = gmtime(&ts);
```

## Fix

Replace with `gmtime_r(3)`, which takes a caller-supplied `struct tm` buffer. This is consistent with how the rest of the codebase already handles UTC time conversion — `gmtime_r` is used in `log.c`, `waypoint.c`, `encode_aprs.c`, and `beacon.c`. The portability shim enabling it on all platforms is already in `direwolf.h`.

A null-return guard is added as the FIXME comment requested.

## Change

```c
// Before
ptm = gmtime(&ts);  // not thread safe; could return NULL

// After
ptm = gmtime_r(&ts, &tm_buf);
if (ptm == NULL) return ((time_t)0);
```

Net change: 3 insertions, 4 deletions (removes the two FIXME comment lines).

Compiled and verified against `direwolf.h` include path.