### PR TITLE
fix: remove leftover debug output from aprs_general_query

### DIFF
--- a/src/decode_aprs.c
+++ b/src/decode_aprs.c
@@ -2646,11 +2646,6 @@ static void aprs_general_query (decode_aprs_t *A, char *info, int ilen, int quie
 	*q2 = '\0';
 	strlcpy (A->g_query_type, stemp+1, sizeof(A->g_query_type));
 
-// TODO: remove debug
-
-	text_color_set(DW_COLOR_DEBUG);
-	dw_printf("DEBUG: General Query type = \"%s\"\n", A->g_query_type);
-
 	p = q2 + 1;
 	if (strlen(p) == 0) {
 	  return;
@@ -2723,11 +2718,6 @@ static void aprs_general_query (decode_aprs_t *A, char *info, int ilen, int quie
 	  return;
 	}
 	
-// TODO: remove debug
-
-	text_color_set(DW_COLOR_DEBUG);
-	dw_printf("DEBUG: General Query footprint = %.6f %.6f %.2f\n", lat, lon, radius);
-
 
 } /* end aprs_general_query */
 


### PR DESCRIPTION
## Summary

Two `TODO: remove debug` markers in `aprs_general_query()` flag unconditional debug print statements that were left in from development:

- Line 2649: prints the decoded query type (`DEBUG: General Query type = "..."`) on every General Query packet
- Line 2726: prints the decoded footprint coordinates (`DEBUG: General Query footprint = ...`) on every General Query packet

Both use `DW_COLOR_DEBUG` / `dw_printf` unconditionally — not guarded by any quiet flag or compile-time switch — so they produce output during normal operation.

## Change

Remove both debug blocks and their TODO comments. Net: 10 deletions, 0 insertions.

Compiled and verified clean against `direwolf.h` include path.