### PR TITLE
fix: suppress false CTCSS tone warning for percentage values

### DIFF
--- a/src/decode_aprs.c
+++ b/src/decode_aprs.c
@@ -4539,7 +4539,7 @@ static void process_comment (decode_aprs_t *A, char *pstart, int clen)
 	    dw_printf("%s:%d: %s\n", __FILE__, __LINE__, emsg);
 	  }
 
-	  e = regcomp (&bad_tone_re, "(^|[^0-9.])([6789][0-9]\\.[0-9]|[12][0-9][0-9]\\.[0-9]|67|77|100|123)($|[^0-9.])", REG_EXTENDED);
+	  e = regcomp (&bad_tone_re, "(^|[^0-9.])([6789][0-9]\\.[0-9]|[12][0-9][0-9]\\.[0-9]|67|77|100|123)($|[^0-9.%])", REG_EXTENDED);
 	  if (e) {
 	    regerror (e, &bad_tone_re, emsg, sizeof(emsg));
 	    dw_printf("%s:%d: %s\n", __FILE__, __LINE__, emsg);
@@ -4938,9 +4938,7 @@ static void process_comment (decode_aprs_t *A, char *pstart, int clen)
 	  }
 	}
 
-// TODO: Don't complain if followed by %.  e.g. Battery voltage 100%.
-
-	if (A->g_tone == G_UNKNOWN && regexec (&bad_tone_re, A->g_comment, MAXMATCH, match, 0) == 0) 
+	if (A->g_tone == G_UNKNOWN && regexec (&bad_tone_re, A->g_comment, MAXMATCH, match, 0) == 0)
 	{
 	  char bad1[30];	/* original 99.9 or 999.9 format or one of 67 77 100 123 */
 	  char bad2[30];	/* 99.9 or 999.9 format.  ".0" appended for special cases. */


### PR DESCRIPTION
## Summary

Addresses the TODO at `decode_aprs.c` line 4941:

```c
// TODO: Don't complain if followed by %.  e.g. Battery voltage 100%.
```

The `bad_tone_re` regex matches numbers that look like misformatted CTCSS tones (67, 77, 100, 123, and decimal variants). The trailing boundary group `($|[^0-9.])` also matched `%`, so a comment containing `Battery voltage 100%` (or `67%`, `77%`, `123%`) triggered a spurious:

```
"100" in comment looks like it might be a CTCSS tone in non-standard format.
```

## Fix

Exclude `%` from the trailing boundary group: `($|[^0-9.])` → `($|[^0-9.%])`.

A number immediately followed by `%` is clearly a percentage, not a tone value. Standalone numeric values that genuinely look like misformatted tones are unaffected.

One-character regex change; two comment lines removed.