### PR TITLE
fix: suppress audio-level messages for non-radio channels

### DIFF
--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -1312,8 +1312,7 @@ void app_process_rec_packet (int chan, int subchan, int slice, packet_t pp, alev
 // The HEARD line.
 
 	if (( ! q_h_opt ) && alevel.rec >= 0) {    /* suppress if "-q h" option */
-// FIXME: rather than checking for ichannel, how about checking medium==radio
-	 if (chan != audio_config.igate_vchannel) {	// suppress if from ICHANNEL
+	 if (audio_config.chan_medium[chan] == MEDIUM_RADIO) {
 	  if (h != -1 && h != AX25_SOURCE) {
 	    dw_printf ("Digipeater ");
 	  }
@@ -1374,18 +1373,15 @@ void app_process_rec_packet (int chan, int subchan, int slice, packet_t pp, alev
 	/* Version 1.2:   Cranking the input level way up produces 199. */
 	/* Keeping it under 100 gives us plenty of headroom to avoid saturation. */
 
-	// TODO:  suppress this message if not using soundcard input.
-	// i.e. we have no control over the situation when using SDR.
-
-	if (!q_h_opt && alevel.rec > 110) {
+	if (!q_h_opt && alevel.rec > 110 && audio_config.chan_medium[chan] == MEDIUM_RADIO) {
 
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Audio input level is too high. This may cause distortion and reduced decode performance.\n");
 	  dw_printf ("Solution is to decrease the audio input level.\n");
 	  dw_printf ("Setting audio input level so most stations are around 50 will provide good dyanmic range.\n");
 	}
-// FIXME: rather than checking for ichannel, how about checking medium==radio
-	else if (alevel.rec < 5 && chan != audio_config.igate_vchannel && subchan != SUBCHAN_NETTNC && subchan != SUBCHAN_SERTNC) {
+	else if (alevel.rec < 5 && audio_config.chan_medium[chan] == MEDIUM_RADIO
+	         && subchan != SUBCHAN_NETTNC && subchan != SUBCHAN_SERTNC) {
 
 	  text_color_set(DW_COLOR_ERROR);
 	  dw_printf ("Audio input level is too low.  Increase so most stations are around 50.\n");


### PR DESCRIPTION
Closes #452.

Two FIXME comments in `app_process_rec_packet()` asked for exactly this change:

> FIXME: rather than checking for ichannel, how about checking medium==radio

This replaces both `chan != audio_config.igate_vchannel` comparisons with
`audio_config.chan_medium[chan] == MEDIUM_RADIO`, and applies the same guard to
the "audio input level too high" warning (which had a matching TODO noting it
should be suppressed when not using soundcard input).

**Effect:** the HEARD line and all three audio-level warnings are now silenced
for virtual / network / SDR channels (e.g. RTL-FM piped to stdin, gqrx UDP),
where the application has no control over the signal level. They continue to
appear for soundcard radio channels where the user can actually act on them.

The two FIXME and one TODO comments are removed as the intent is now implemented.

**Testing:** reviewed against `direwolf.c`; no functional change expected for
standard soundcard configurations.