### PR TITLE
Add TIMESTAMP config file directive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### New Features:
 
+- New `TIMESTAMP` config file directive.  Equivalent to the `-T` command line option, for use when Direwolf is launched by a supervisor (e.g. Winlink Express) that can't pass command-line arguments.  See issue #625.
+
 - Improved generation of SREJ frames for more efficient AX.25 v2.2 connected mode.
 
 - Add delay before exit so any error messages can be read before window disappears.

--- a/conf/generic.conf
+++ b/conf/generic.conf
@@ -356,3 +356,15 @@
 %C%# https://raw.githubusercontent.com/wb2osz/direwolf/master/doc/APRStt-Implementation-Notes.pdf
 %C%#
 
+%C%
+%C%#############################################################
+%C%#                                                           #
+%C%#               TIME STAMPS                                 #
+%C%#                                                           #
+%C%#############################################################
+%C%
+%C%# Precede received & transmitted frames with a time stamp, using
+%C%# a "strftime" format string.  Same effect as the -T command line
+%C%# option, which takes precedence over this if both are used.
+%C%#
+%C%#TIMESTAMP %H:%M:%S

--- a/man/direwolf.1
+++ b/man/direwolf.1
@@ -196,6 +196,7 @@ Report audio device statistics each n seconds.
 .TP
 .BI "-T " "fmt"
 Time stamp format for sent and received frames.
+Overrides the TIMESTAMP directive in the configuration file, if also present.
 
 .TP
 .BI "-e " "ber"

--- a/src/audio.h
+++ b/src/audio.h
@@ -126,9 +126,9 @@ struct audio_s {
 					/* Future: not used yet. */
 
 
-	char timestamp_format[40];	/* -T option */
+	char timestamp_format[40];	/* -T option, or TIMESTAMP in config file. */
 					/* Precede received & transmitted frames with timestamp. */
-					/* Command line option uses "strftime" format string. */
+					/* Uses "strftime" format string.  -T takes precedence over config file. */
 
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -5479,6 +5479,23 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 	  }
 
 /*
+ * TIMESTAMP	fmt	- Time stamp format for sent and received frames.
+ *			  Same as the -T command line option, which takes precedence
+ *			  if also specified.  Uses "strftime" format string, e.g. "%H:%M:%S ".
+ */
+	  else if (strcasecmp(t, "TIMESTAMP") == 0) {
+	    t = split(NULL,1);
+	    if (t == NULL) {
+	      text_color_set(DW_COLOR_ERROR);
+	      dw_printf ("Config file: Missing time stamp format for TIMESTAMP on line %d.\n", line);
+	      continue;
+	    }
+	    else {
+	      strlcpy (p_audio_config->timestamp_format, t, sizeof(p_audio_config->timestamp_format));
+	    }
+	  }
+
+/*
  * BEACON channel delay every message
  *
  * Original handcrafted style.  Removed in version 1.0.

--- a/src/config.c
+++ b/src/config.c
@@ -5491,6 +5491,10 @@ void config_init (char *fname, struct audio_s *p_audio_config,
 	      continue;
 	    }
 	    else {
+	      if (strlen(t) >= sizeof(p_audio_config->timestamp_format)) {
+	        text_color_set(DW_COLOR_ERROR);
+	        dw_printf ("Config file: TIMESTAMP format on line %d is too long and will be truncated.\n", line);
+	      }
 	      strlcpy (p_audio_config->timestamp_format, t, sizeof(p_audio_config->timestamp_format));
 	    }
 	  }

--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -214,9 +214,10 @@ int main (int argc, char *argv[])
 	char L_opt_logfile[80];
 	char input_file[80];
 	char T_opt_timestamp[40];
-	
+	int T_opt_present = 0;	/* True when -T was specified on command line. */
+
 	int t_opt = 1;		/* Text color option. */
-	char o_opt[80] = "";	// Console capture received raw packets. 
+	char o_opt[80] = "";	// Console capture received raw packets.
 	char O_opt[80] = "";	// Console capture all output.
 
 	int a_opt = 0;		/* "-a n" interval, in seconds, for audio statistics report.  0 for none. */
@@ -768,6 +769,7 @@ int main (int argc, char *argv[])
 
           case 'T':				/* -T for receive timestamp. */
 	    strlcpy (T_opt_timestamp, optarg, sizeof(T_opt_timestamp));
+	    T_opt_present = 1;
             break;
 
 	  case 'e':				/* -e Receive Bit Error Rate (BER). */
@@ -956,7 +958,9 @@ int main (int argc, char *argv[])
 	    audio_config.achan[0].upsample = U_opt;
 	}
 
-	strlcpy(audio_config.timestamp_format, T_opt_timestamp, sizeof(audio_config.timestamp_format));
+	if (T_opt_present) {
+	  strlcpy(audio_config.timestamp_format, T_opt_timestamp, sizeof(audio_config.timestamp_format));
+	}
 
 	// temp - only xmit errors.
 

--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -1884,6 +1884,7 @@ static void usage (void)
 	dw_printf ("    -u             Print UTF-8 test string and exit.\n");
 	dw_printf ("    -S             Print symbol tables and exit.\n");
 	dw_printf ("    -T fmt         Time stamp format for sent and received frames.\n");
+	dw_printf ("                   Overrides TIMESTAMP in the configuration file, if also present.\n");
 	dw_printf ("    -e ber         Receive Bit Error Rate (BER), e.g. 1e-5\n");
 	dw_printf ("\n");
 

--- a/src/dtime_now.c
+++ b/src/dtime_now.c
@@ -250,7 +250,10 @@ void timestamp_user_format (char *result, int result_size, char *user_format)
 	struct tm tm;
 
 	localtime_r (&t, &tm);
-	strftime (result, result_size, user_format, &tm);
+	if (strftime (result, result_size, user_format, &tm) == 0) {
+	  // Expansion didn't fit in result_size.  Contents are unspecified per C standard; don't print them.
+	  result[0] = '\0';
+	}
 
 }  /* end timestamp_user_format */
 


### PR DESCRIPTION
## Summary

- Adds a `TIMESTAMP fmt` directive to `direwolf.conf`, equivalent to the existing `-T fmt` command-line option, so timestamps on sent/received frames can be enabled when Direwolf is launched by a supervisor (e.g. Winlink Express) that can't pass command-line arguments. Closes #625.
- Fixes a pre-existing bug where `-T` unconditionally overwrote the timestamp format after config-file parsing, even when `-T` wasn't given on the command line — this would otherwise have silently clobbered the new `TIMESTAMP` directive. `-T` still takes precedence over `TIMESTAMP` when both are given (including using `-T ""` to explicitly disable a config-file setting).
- Updates the `-T` help text and man page to mention the new directive, adds a commented-out example to `conf/generic.conf`, and adds a `CHANGES.md` entry.
- Also adds a couple of small hardening touches found during review: a warning (instead of silent truncation) when a `TIMESTAMP` format string exceeds the 40-byte field, and a fix in `timestamp_user_format()` for the (pre-existing, on both `-T` and `TIMESTAMP`) case where `strftime()`'s expansion doesn't fit the output buffer.

## Test plan

No automated test harness covers config-file parsing or CLI option handling in this repo, so verification was manual, using the repo's own `gen_packets` tool to synthesize a decodable test packet:

- [x] `TIMESTAMP %H:%M:%S ` alone (no `-T`) enables timestamps on decoded frames
- [x] `-T` on the command line still overrides a `TIMESTAMP` config-file value
- [x] Omitting both leaves timestamps off (no regression to current default)
- [x] `-T ""` on the command line can explicitly disable a config-file `TIMESTAMP`
- [x] `TIMESTAMP` with no argument reports a config error and continues
- [x] A `TIMESTAMP` format longer than 40 bytes now warns instead of silently truncating
- [x] `direwolf -h` and `man direwolf` both document the new directive
- [x] Full `ctest` suite (24/24 tests) passes