### PR TITLE
Optional AGWPE extension exposing per-frame signal quality

### DIFF
--- a/doc/AGWPE-signal-quality-extension.md
+++ b/doc/AGWPE-signal-quality-extension.md
@@ -1,0 +1,61 @@
+# AGWPE extension: per-frame signal quality in monitor frames
+
+Optional, opt-in extension to Direwolf's AGWPE server.
+
+## What it does
+
+Carries Direwolf's per-frame demodulator metrics (`alevel.rec`, `.mark`,
+`.space`, and the retry/FEC level) to AGWPE clients **in-band on the existing
+`'U'/'S'/'I'` monitor frames**, so a client can display RF signal quality for
+the stations it hears. Direwolf normally emits these only to stdout and the
+APRS-only CSV log — never over AGWPE.
+
+## Backwards compatibility
+
+A stock AGWPE client (Xastir, APRSIS32, UI-View, YAAC, …) connected to a patched
+Direwolf **still sees byte-identical frames**. Guaranteed by making the extension
+per-client opt-in: the extra bytes are written only in the copy sent to a
+client that explicitly enabled it.
+
+## Protocol
+
+**Carrier** — the `struct agwpe_s` header `user_reserved` field (bytes 32–35),
+already `memset` to 0 in `server_send_monitored`. For opted-in clients only, on
+`'U'/'S'/'I'` frames, four raw bytes:
+
+```
+user_reserved[0] = rec       (clamped 0..255)
+user_reserved[1] = mark      (0..255; 0xFF = N/A for non-AFSK)
+user_reserved[2] = space     (0..255; 0xFF = N/A)
+user_reserved[3] = retries   (0 = clean copy)
+```
+
+Raw bytes (not `host2netle`). The monitor text payload and all lengths are
+unchanged.
+
+**Handshake** — new client→server datakind **`'q'`** ("enable extended signal
+reporting"):
+- On receipt, set `enable_ext_sig_to_client[client]` and reply once with an ACK
+  frame (datakind `'q'`, payload `"ExtSig=1"`) so the client can confirm support.
+- Reset the flag wherever `enable_send_monitor_to_client` is reset (new
+  connection / init).
+- A stock Direwolf treats `'q'` as an unknown command (benign default) → never
+  sets the flag, never ACKs, `user_reserved` stays 0.
+
+## Code touch points
+
+- `src/server.h` — add `alevel_t alevel, int retries` to `server_send_rec_packet`
+  and `server_send_monitored` declarations.
+- `src/server.c`
+  - `static int enable_ext_sig_to_client[MAX_NET_CLIENTS];` + resets (3 sites).
+  - `case 'q':` in the client-command dispatch (+ ACK, + debug label).
+  - Thread `alevel`/`retries` through `server_send_rec_packet` →
+    `server_send_monitored`; write `user_reserved` for opted-in clients when
+    `alevel.rec >= 0`.
+- `src/direwolf.c` — pass `alevel, retries` at the two `server_send_rec_packet`
+  call sites (`app_process_rec_packet` has both in scope).
+- `src/xmit.c` — own-TX `'T'`: pass a `rec = -1` sentinel (no signal).
+- `src/tt_user.c` — APRStt object: pass a `rec = -1` sentinel.
+
+Sentinel `rec < 0` ⇒ `server_send_monitored` writes no reserved bytes, so `'T'`
+and synthetic frames are unaffected.

--- a/src/direwolf.c
+++ b/src/direwolf.c
@@ -1657,7 +1657,7 @@ int app_process_rec_packet (int chan, int subchan, int slice, packet_t pp, aleve
 
 	flen = ax25_pack(pp, fbuf);
 
-	server_send_rec_packet (chan, pp, fbuf, flen);					// AGW net protocol
+	server_send_rec_packet (chan, pp, fbuf, flen, alevel, retries);			// AGW net protocol
 	kissnet_send_rec_packet (chan, KISS_CMD_DATA_FRAME, fbuf, flen, NULL, -1);	// KISS TCP
 	kissserial_send_rec_packet (chan, KISS_CMD_DATA_FRAME, fbuf, flen, NULL, -1);	// KISS serial port
 	kisspt_send_rec_packet (chan, KISS_CMD_DATA_FRAME, fbuf, flen, NULL, -1);	// KISS pseudo terminal
@@ -1668,7 +1668,9 @@ int app_process_rec_packet (int chan, int subchan, int slice, packet_t pp, aleve
 	    unsigned char ao_fbuf[AX25_MAX_PACKET_LEN];
 	    int ao_flen = ax25_pack(ao_pp, ao_fbuf);
 
-	    server_send_rec_packet (chan, ao_pp, ao_fbuf, ao_flen);
+	    // Synthetic object derived from an AIS reception — no direct RF signal
+	    // to attribute, so pass a "no measurement" sentinel (rec < 0).
+	    server_send_rec_packet (chan, ao_pp, ao_fbuf, ao_flen, (alevel_t){.rec = -1, .mark = -1, .space = -1}, 0);
 	    kissnet_send_rec_packet (chan, KISS_CMD_DATA_FRAME, ao_fbuf, ao_flen, NULL, -1);
 	    kissserial_send_rec_packet (chan, KISS_CMD_DATA_FRAME, ao_fbuf, ao_flen, NULL, -1);
 	    kisspt_send_rec_packet (chan, KISS_CMD_DATA_FRAME, ao_fbuf, ao_flen, NULL, -1);

--- a/src/server.c
+++ b/src/server.c
@@ -196,6 +196,13 @@ static int enable_send_raw_to_client[MAX_NET_CLIENTS];
 static int enable_send_monitor_to_client[MAX_NET_CLIENTS];
 					/* Should we send received packets to client app in monitor form? */
 					/* Note that it starts as false for a new connection. */
+
+static int enable_ext_sig_to_client[MAX_NET_CLIENTS];
+					/* Optional extension (non-standard): when set, monitor frames sent to */
+					/* this client carry per-frame signal quality in the otherwise-zero */
+					/* user_reserved header bytes.  Enabled by the 'q' command; stays */
+					/* false for stock clients so they see byte-identical frames. */
+					/* See AGWPE-SIGNAL-QUALITY-EXTENSION.md. */
 					/* the client app must send a command to enable this. */
 
 
@@ -348,6 +355,7 @@ static void debug_print (fromto_t fromto, int client, struct agwpe_s *pmsg, int 
 	      case 'x': strlcpy (datakind, "Unregister CallSign",			sizeof(datakind)); break;
 	      case 'G': strlcpy (datakind, "Ask Port Information",			sizeof(datakind)); break;
 	      case 'm': strlcpy (datakind, "Enable Reception of Monitoring Frames",	sizeof(datakind)); break;
+	      case 'q': strlcpy (datakind, "Enable Extended Signal Quality",		sizeof(datakind)); break;
 	      case 'R': strlcpy (datakind, "AGWPE Version Info",			sizeof(datakind)); break;
 	      case 'g': strlcpy (datakind, "Ask Port Capabilities",			sizeof(datakind)); break;
 	      case 'H': strlcpy (datakind, "Callsign Heard on a Port",			sizeof(datakind)); break;
@@ -514,6 +522,7 @@ void server_init (struct audio_s *audio_config_p, struct misc_config_s *mc)
 	  client_sock[client] = -1;
 	  enable_send_raw_to_client[client] = 0;
 	  enable_send_monitor_to_client[client] = 0;
+	  enable_ext_sig_to_client[client] = 0;
 	}
 
 	if (server_port == 0) {
@@ -713,6 +722,7 @@ static THREAD_F connect_listen_thread (void *arg)
  */ 
 	    enable_send_raw_to_client[client] = 0;
 	    enable_send_monitor_to_client[client] = 0;
+	    enable_ext_sig_to_client[client] = 0;
 	  }
 	  else {
 	    SLEEP_SEC(1);	/* wait then check again if more clients allowed. */
@@ -804,6 +814,7 @@ static THREAD_F connect_listen_thread (void *arg)
  */ 
 	    enable_send_raw_to_client[client] = 0;
 	    enable_send_monitor_to_client[client] = 0;
+	    enable_ext_sig_to_client[client] = 0;
 	  }
 	  else {
 	    SLEEP_SEC(1);	/* wait then check again if more clients allowed. */
@@ -841,7 +852,7 @@ static void mon_addrs (int chan, packet_t pp, char *result, int result_size);
 static char mon_desc (packet_t pp, char *result, int result_size);
 
 
-void server_send_rec_packet (int chan, packet_t pp, unsigned char *fbuf,  int flen)
+void server_send_rec_packet (int chan, packet_t pp, unsigned char *fbuf,  int flen, alevel_t alevel, int retries)
 {
 	struct {	
 	  struct agwpe_s hdr;
@@ -905,13 +916,13 @@ void server_send_rec_packet (int chan, packet_t pp, unsigned char *fbuf,  int fl
 
 	// Application might want more human readable format.
 
-	server_send_monitored (chan, pp, 0);
+	server_send_monitored (chan, pp, 0, alevel, retries);
 
 } /* end server_send_rec_packet */
 
 
 
-void server_send_monitored (int chan, packet_t pp, int own_xmit)
+void server_send_monitored (int chan, packet_t pp, int own_xmit, alevel_t alevel, int retries)
 {
 /*
  * MONITOR format - 	'I' for information frames.
@@ -994,6 +1005,19 @@ void server_send_monitored (int chan, packet_t pp, int own_xmit)
 
 	    agwpe_msg.data[msg_data_len++] = '\0';	// add nul at end, included in length.
 	    agwpe_msg.hdr.data_len_NETLE = host2netle(msg_data_len);
+
+	    // Optional extension (non-standard, opt-in via 'q'): stash per-frame signal
+	    // quality in the otherwise-zero user_reserved header bytes.  Only for
+	    // clients that asked, so stock clients get byte-identical frames.
+	    // alevel.rec < 0 means "no measurement" (e.g. own transmitted frames).
+	    // See AGWPE-SIGNAL-QUALITY-EXTENSION.md.
+	    if (enable_ext_sig_to_client[client] && alevel.rec >= 0) {
+	      unsigned char *sig = (unsigned char *)(&agwpe_msg.hdr.user_reserved_NETLE);
+	      sig[0] = (unsigned char) (alevel.rec   > 255 ? 255 : alevel.rec);
+	      sig[1] = (unsigned char) (alevel.mark  < 0 ? 0xFF : (alevel.mark  > 255 ? 255 : alevel.mark));
+	      sig[2] = (unsigned char) (alevel.space < 0 ? 0xFF : (alevel.space > 255 ? 255 : alevel.space));
+	      sig[3] = (unsigned char) (retries < 0 ? 0 : (retries > 255 ? 255 : retries));
+	    }
 
 	    if (debug_client) {
 	      debug_print (TO_CLIENT, client, &agwpe_msg.hdr, sizeof(agwpe_msg.hdr) + netle2host(agwpe_msg.hdr.data_len_NETLE));
@@ -1822,6 +1846,30 @@ static THREAD_F cmd_listen_thread (void *arg)
 	      // Actually it is a toggle so we must be sure to clear it for a new connection.
 
 	      enable_send_monitor_to_client[client] = ! enable_send_monitor_to_client[client];
+	      break;
+
+
+	    case 'q':				/* Optional extension: enable extended signal quality reporting */
+
+	      // Non-standard extension (see AGWPE-SIGNAL-QUALITY-EXTENSION.md).
+	      // Turn on per-frame signal quality in the user_reserved header bytes
+	      // of monitor frames sent to THIS client, then acknowledge so the
+	      // client can positively confirm the server supports it.  Stock clients
+	      // never send 'q', so their frames are byte-for-byte unchanged.
+	      {
+		struct {
+		  struct agwpe_s hdr;
+		  char data[16];
+		} reply;
+
+		enable_ext_sig_to_client[client] = 1;
+
+		memset (&reply, 0, sizeof(reply));
+		reply.hdr.datakind = 'q';
+		strlcpy (reply.data, "ExtSig=1", sizeof(reply.data));
+		reply.hdr.data_len_NETLE = host2netle(strlen(reply.data) + 1);
+		send_to_client (client, &reply);
+	      }
 	      break;
 
 

--- a/src/server.h
+++ b/src/server.h
@@ -13,9 +13,9 @@ void server_set_debug (int n);
 
 void server_init (struct audio_s *audio_config_p, struct misc_config_s *misc_config);
 
-void server_send_rec_packet (int chan, packet_t pp, unsigned char *fbuf,  int flen);
+void server_send_rec_packet (int chan, packet_t pp, unsigned char *fbuf,  int flen, alevel_t alevel, int retries);
 
-void server_send_monitored (int chan, packet_t pp, int own_xmit);
+void server_send_monitored (int chan, packet_t pp, int own_xmit, alevel_t alevel, int retries);
 
 int server_callsign_registered_by_client (char *callsign);
 

--- a/src/tt_user.c
+++ b/src/tt_user.c
@@ -896,7 +896,8 @@ static void xmit_object_report (int i, int first_time)
 
 	  flen = ax25_pack(pp, fbuf);
 
-	  server_send_rec_packet (save_tt_config_p->obj_recv_chan, pp, fbuf, flen);
+	  // Synthetic APRStt object — no direct RF signal, pass a sentinel (rec < 0).
+	  server_send_rec_packet (save_tt_config_p->obj_recv_chan, pp, fbuf, flen, (alevel_t){.rec = -1, .mark = -1, .space = -1}, 0);
 	  kissnet_send_rec_packet (save_tt_config_p->obj_recv_chan, KISS_CMD_DATA_FRAME, fbuf, flen, NULL, -1);
 	  kissserial_send_rec_packet (save_tt_config_p->obj_recv_chan, KISS_CMD_DATA_FRAME, fbuf, flen, NULL, -1);
 	  kisspt_send_rec_packet (save_tt_config_p->obj_recv_chan, KISS_CMD_DATA_FRAME, fbuf, flen, NULL, -1);

--- a/src/xmit.c
+++ b/src/xmit.c
@@ -1091,8 +1091,9 @@ static int send_one_frame (int c, int p, packet_t pp)
 	nb = layer2_send_frame (c, pp, send_invalid_fcs2, save_audio_config_p);
 
 // Optionally send confirmation to AGW client app if monitoring enabled.
+// Own transmitted frame — no received signal, so pass a sentinel (rec < 0).
 
-	server_send_monitored (c, pp, 1);
+	server_send_monitored (c, pp, 1, (alevel_t){.rec = -1, .mark = -1, .space = -1}, 0);
 
 	return (nb);
 


### PR DESCRIPTION
Direwolf measures a per-frame signal metric — audio level rec(mark/space) plus the retry/FEC decode level — but only emits it to stdout and the APRS-only CSV log, never over the AGWPE monitor API. This adds an opt-in, backwards-compatible way for an AGWPE client to receive it in-band.

A client enables the feature with a new 'q' command; the server replies with a 'q' frame carrying "ExtSig=1". For clients that opted in, the per-frame metrics are packed into the four otherwise-zero user_reserved header bytes of 'U'/'S'/'I' monitor frames:

    user_reserved[0] = rec      (0..255)
    user_reserved[1] = mark     (0..255; 0xFF = N/A for non-AFSK)
    user_reserved[2] = space    (0..255; 0xFF = N/A)
    user_reserved[3] = retries  (0 = clean copy)

Backwards compatibility: the bytes are written only in the copy sent to a client that sent 'q', after the header is zeroed, so any client that does not opt in — every stock AGWPE client — receives byte-identical frames. A stock Direwolf ignores the unknown 'q' command, so a client requesting the extension against stock never sees the ACK and leaves the feature off.

alevel and the retry count are threaded from app_process_rec_packet through server_send_rec_packet into server_send_monitored. Own transmitted ('T') frames and synthetic packets (AIS objects, APRStt) pass a rec = -1 sentinel, which suppresses the reserved-byte write.

This is used in the "BBS2" project at github.com/elafargue/bbs2 where the "heard" plugin is able to display link quality for neighbors.